### PR TITLE
Add scheduled polling for Google integrations

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4,8 +4,10 @@ Clients for external services such as HubSpot and Google APIs.
 
 ## Files
 - `hubspot_api.py`
-- `google_calendar.py`: poll events and filter by trigger words.
-- `google_contacts.py`: fetch contacts and filter by trigger words.
+- `google_calendar.py`: scheduled polling of events with trigger-word
+  filtering and normalized payloads.
+- `google_contacts.py`: scheduled polling of contacts with trigger-word
+  filtering and normalized payloads.
 - `email_sender.py`: SMTP e-mail helper.
 - `web_scraper.py`
 - `sources_registry.py`

--- a/tests/unit/test_google_polling.py
+++ b/tests/unit/test_google_polling.py
@@ -1,0 +1,65 @@
+"""Tests for Google Calendar and Contacts scheduled polling."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from integrations import google_calendar, google_contacts  # noqa: E402
+from core import trigger_words  # noqa: E402
+
+
+def test_calendar_scheduled_poll_normalizes(monkeypatch):
+    events = [{"creator": "alice@example.com", "summary": "Test"}]
+    monkeypatch.setattr(google_calendar, "fetch_events", lambda: events)
+
+    result = google_calendar.scheduled_poll()
+
+    assert result == [
+        {
+            "creator": "alice@example.com",
+            "trigger_source": "calendar",
+            "recipient": "alice@example.com",
+            "payload": events[0],
+        }
+    ]
+
+
+def test_contacts_scheduled_poll_normalizes(monkeypatch):
+    contacts = [
+        {
+            "emailAddresses": [{"value": "bob@example.com"}],
+            "names": [],
+            "notes": "research",
+        }
+    ]
+    monkeypatch.setattr(google_contacts, "fetch_contacts", lambda: contacts)
+
+    result = google_contacts.scheduled_poll()
+
+    assert result == [
+        {
+            "creator": "bob@example.com",
+            "trigger_source": "contacts",
+            "recipient": "bob@example.com",
+            "payload": contacts[0],
+        }
+    ]
+
+
+def test_fetch_events_exits_early_when_no_triggers(tmp_path, monkeypatch):
+    path = tmp_path / "triggers.txt"
+    path.write_text("")
+    monkeypatch.setenv("TRIGGER_WORDS_FILE", str(path))
+    trigger_words.load_trigger_words.cache_clear()
+
+    assert google_calendar.fetch_events() == []
+
+
+def test_fetch_contacts_exits_early_when_no_triggers(tmp_path, monkeypatch):
+    path = tmp_path / "triggers.txt"
+    path.write_text("")
+    monkeypatch.setenv("TRIGGER_WORDS_FILE", str(path))
+    trigger_words.load_trigger_words.cache_clear()
+
+    assert google_contacts.fetch_contacts() == []


### PR DESCRIPTION
## Summary
- add trigger-word-aware event polling for Google Calendar
- add trigger-word-aware contact polling for Google Contacts
- centralize trigger word loading via `TRIGGER_WORDS_FILE`
- document new scheduled polling features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ebb24668832b87a5766ae8b7d27a