### PR TITLE
Implement orchestrator pipeline with feature flags and retries

### DIFF
--- a/integrations/hubspot_api.py
+++ b/integrations/hubspot_api.py
@@ -1,5 +1,14 @@
 """HubSpot API client stub."""
 
+
 def upsert_company(data):
     """Upsert company data to HubSpot."""
     pass
+
+
+def attach_pdf(pdf_path):
+    """Attach a PDF to the HubSpot record."""
+    pass
+
+
+__all__ = ["upsert_company", "attach_pdf"]

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from core import orchestrator
+from core import orchestrator, feature_flags
 
 
 def test_gather_triggers_normalizes_data():
@@ -30,23 +30,81 @@ def test_gather_triggers_normalizes_data():
             "payload": contacts[0],
         },
     ]
+def test_run_pipeline_respects_feature_flags(monkeypatch):
+    monkeypatch.setattr(feature_flags, "USE_PUSH_TRIGGERS", False)
+    monkeypatch.setattr(feature_flags, "ENABLE_PRO_SOURCES", False)
+    monkeypatch.setattr(feature_flags, "ATTACH_PDF_TO_HUBSPOT", True)
 
-
-def test_run_sends_email(monkeypatch):
     events = [{"creator": "carol@example.com"}]
     contacts = []
-    sent = []
 
-    def fake_send(to, subject, body, attachments=None):  # pragma: no cover - simple stub
-        sent.append((to, subject, body))
+    called = {"basic": 0, "pro": 0, "pdf": 0, "csv": 0, "upsert": 0, "attach": 0}
 
-    orchestrator.run(lambda: events, lambda: contacts, send=fake_send)
+    def basic(trigger):
+        called["basic"] += 1
+        return {"basic": True}
 
-    assert sent == [
-        (
-            "carol@example.com",
-            "Research workflow triggered",
-            "Trigger source: calendar",
-        )
-    ]
+    def pro(trigger):
+        called["pro"] += 1
+        return {"pro": True}
+
+    pro.pro = True  # mark as pro-only
+
+    def fake_consolidate(results):
+        return {"results": results}
+
+    def fake_pdf(data, path):
+        called["pdf"] += 1
+
+    def fake_csv(data, path):
+        called["csv"] += 1
+
+    def fake_upsert(data):
+        called["upsert"] += 1
+
+    def fake_attach(path):
+        called["attach"] += 1
+
+    orchestrator.run(
+        event_fetcher=lambda: events,
+        contact_fetcher=lambda: contacts,
+        researchers=[basic, pro],
+        consolidate_fn=fake_consolidate,
+        pdf_renderer=fake_pdf,
+        csv_exporter=fake_csv,
+        hubspot_upsert=fake_upsert,
+        hubspot_attach=fake_attach,
+    )
+
+    assert called["basic"] == 1
+    assert called["pro"] == 0
+    assert called["pdf"] == 1
+    assert called["csv"] == 1
+    assert called["upsert"] == 1
+    assert called["attach"] == 1
+
+
+def test_run_skips_intake_when_push_triggers_enabled(monkeypatch):
+    monkeypatch.setattr(feature_flags, "USE_PUSH_TRIGGERS", True)
+    monkeypatch.setattr(feature_flags, "ENABLE_PRO_SOURCES", False)
+    monkeypatch.setattr(feature_flags, "ATTACH_PDF_TO_HUBSPOT", False)
+
+    gathered = {"called": False}
+
+    def fake_gather(*args, **kwargs):  # pragma: no cover - simple stub
+        gathered["called"] = True
+        return []
+
+    monkeypatch.setattr(orchestrator, "gather_triggers", fake_gather)
+
+    orchestrator.run(
+        researchers=[],
+        consolidate_fn=lambda x: x,
+        pdf_renderer=lambda d, p: None,
+        csv_exporter=lambda d, p: None,
+        hubspot_upsert=lambda d: None,
+        hubspot_attach=lambda p: None,
+    )
+
+    assert not gathered["called"]
 


### PR DESCRIPTION
## Summary
- Chain intake, research, consolidation, output, and HubSpot stages in the orchestrator.
- Add exponential backoff retries around external calls and honor `USE_PUSH_TRIGGERS`, `ENABLE_PRO_SOURCES`, and `ATTACH_PDF_TO_HUBSPOT` feature flags.
- Extend HubSpot API stub with PDF attachment support and update tests.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f1923330832bad62414036e0e7c8