### PR TITLE
Add research agent stubs and source registry entries

### DIFF
--- a/agents/agent1_internal_company_research.py
+++ b/agents/agent1_internal_company_research.py
@@ -1,5 +1,32 @@
-"""Agent 1 - internal company research stub."""
+"""Agent 1 - internal company research."""
 
-def run():
-    """Run internal company research."""
-    pass
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+Normalized = Dict[str, Any]
+
+
+def run(trigger: Normalized) -> Normalized:
+    """Run internal company research.
+
+    Parameters
+    ----------
+    trigger:
+        Normalized trigger dictionary passed from the orchestrator.
+
+    Returns
+    -------
+    Normalized
+        Structured result following the common schema of ``source``,
+        ``creator``, ``recipient`` and ``payload``.
+    """
+    return {
+        "source": "internal_company_research",
+        "creator": trigger.get("creator"),
+        "recipient": trigger.get("recipient"),
+        "payload": {
+            "summary": "No internal company research available."
+        },
+    }

--- a/agents/agent2_company_search.py
+++ b/agents/agent2_company_search.py
@@ -1,5 +1,32 @@
-"""Agent 2 - company search by classification stub."""
+"""Agent 2 - company search by classification."""
 
-def run():
-    """Run company search by classification."""
-    pass
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+Normalized = Dict[str, Any]
+
+
+def run(trigger: Normalized) -> Normalized:
+    """Run company search by classification.
+
+    Parameters
+    ----------
+    trigger:
+        Normalized trigger dictionary passed from the orchestrator.
+
+    Returns
+    -------
+    Normalized
+        Structured result with ``source``, ``creator``, ``recipient`` and
+        ``payload`` keys.
+    """
+    return {
+        "source": "company_search",
+        "creator": trigger.get("creator"),
+        "recipient": trigger.get("recipient"),
+        "payload": {
+            "companies": [],
+        },
+    }

--- a/agents/agent3_external_branch_research.py
+++ b/agents/agent3_external_branch_research.py
@@ -1,5 +1,32 @@
-"""Agent 3 - external branch research stub."""
+"""Agent 3 - external branch research."""
 
-def run():
-    """Run external branch research."""
-    pass
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+Normalized = Dict[str, Any]
+
+
+def run(trigger: Normalized) -> Normalized:
+    """Run external branch research.
+
+    Parameters
+    ----------
+    trigger:
+        Normalized trigger dictionary passed from the orchestrator.
+
+    Returns
+    -------
+    Normalized
+        Structured result with ``source``, ``creator``, ``recipient`` and
+        ``payload`` keys.
+    """
+    return {
+        "source": "external_branch_research",
+        "creator": trigger.get("creator"),
+        "recipient": trigger.get("recipient"),
+        "payload": {
+            "branches": [],
+        },
+    }

--- a/agents/agent4_external_customer_research.py
+++ b/agents/agent4_external_customer_research.py
@@ -1,5 +1,32 @@
-"""Agent 4 - external customer research stub."""
+"""Agent 4 - external customer research."""
 
-def run():
-    """Run external customer research."""
-    pass
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+Normalized = Dict[str, Any]
+
+
+def run(trigger: Normalized) -> Normalized:
+    """Run external customer research.
+
+    Parameters
+    ----------
+    trigger:
+        Normalized trigger dictionary passed from the orchestrator.
+
+    Returns
+    -------
+    Normalized
+        Structured result with ``source``, ``creator``, ``recipient`` and
+        ``payload`` keys.
+    """
+    return {
+        "source": "external_customer_research",
+        "creator": trigger.get("creator"),
+        "recipient": trigger.get("recipient"),
+        "payload": {
+            "customers": [],
+        },
+    }

--- a/agents/agent5_internal_customer_research.py
+++ b/agents/agent5_internal_customer_research.py
@@ -1,5 +1,32 @@
-"""Agent 5 - internal customer research stub."""
+"""Agent 5 - internal customer research."""
 
-def run():
-    """Run internal customer research."""
-    pass
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+Normalized = Dict[str, Any]
+
+
+def run(trigger: Normalized) -> Normalized:
+    """Run internal customer research.
+
+    Parameters
+    ----------
+    trigger:
+        Normalized trigger dictionary passed from the orchestrator.
+
+    Returns
+    -------
+    Normalized
+        Structured result with ``source``, ``creator``, ``recipient`` and
+        ``payload`` keys.
+    """
+    return {
+        "source": "internal_customer_research",
+        "creator": trigger.get("creator"),
+        "recipient": trigger.get("recipient"),
+        "payload": {
+            "customer_notes": [],
+        },
+    }

--- a/integrations/sources_registry.py
+++ b/integrations/sources_registry.py
@@ -1,3 +1,17 @@
 """Registry of data sources."""
 
-SOURCES = []
+from agents import (
+    agent1_internal_company_research,
+    agent2_company_search,
+    agent3_external_branch_research,
+    agent4_external_customer_research,
+    agent5_internal_customer_research,
+)
+
+SOURCES = [
+    agent1_internal_company_research.run,
+    agent2_company_search.run,
+    agent3_external_branch_research.run,
+    agent4_external_customer_research.run,
+    agent5_internal_customer_research.run,
+]


### PR DESCRIPTION
## Summary
- implement agents 1-5 with shared output schema for internal/external company and customer research
- register all agents in the source registry

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61d348998832b93db84ebc9727668