### PR TITLE
Implement classification and consolidation modules

### DIFF
--- a/core/classify.py
+++ b/core/classify.py
@@ -1,5 +1,71 @@
 """Classification utilities."""
 
-def classify(data):
-    """Classify company data into industry codes and tags."""
-    return {}
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# Simple keyword mapping to WZ2008 classification codes.
+# This is a tiny subset for demonstration purposes only.
+WZ2008_KEYWORDS: Dict[str, str] = {
+    "agriculture": "01",
+    "manufacturing": "28",
+    "software": "62.01",
+    "consulting": "70.22",
+    "retail": "47.19",
+}
+
+
+def _collect_text(data: Any) -> str:
+    """Recursively collect text from ``data``.
+
+    ``data`` may be nested ``dict``/``list``/``str`` structures. Any text
+    encountered is concatenated into a single lowercase string which is then
+    analysed for keyword matches.
+    """
+
+    parts: List[str] = []
+    if isinstance(data, str):
+        parts.append(data.lower())
+    elif isinstance(data, dict):
+        for value in data.values():
+            parts.append(_collect_text(value))
+    elif isinstance(data, list):
+        for value in data:
+            parts.append(_collect_text(value))
+    return " ".join(p for p in parts if p)
+
+
+def classify(data: Dict[str, Any]) -> Dict[str, List[str]]:
+    """Classify company data into WZ2008 codes and GPT tags.
+
+    Parameters
+    ----------
+    data:
+        Arbitrary nested structure describing a company. Textual values are
+        scanned for keywords which are mapped to WZ2008 codes. GPT tags may be
+        supplied explicitly via a ``gpt_tags`` key.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``wz2008`` and ``gpt_tags`` keys mapping to lists of
+        matched codes/tags.
+    """
+
+    text = _collect_text(data)
+
+    wz_codes: List[str] = []
+    tags: List[str] = []
+
+    for keyword, code in WZ2008_KEYWORDS.items():
+        if keyword in text:
+            if code not in wz_codes:
+                wz_codes.append(code)
+            if keyword not in tags:
+                tags.append(keyword)
+
+    for tag in data.get("gpt_tags", []):
+        if tag not in tags:
+            tags.append(tag)
+
+    return {"wz2008": wz_codes, "gpt_tags": tags}

--- a/core/consolidate.py
+++ b/core/consolidate.py
@@ -1,5 +1,52 @@
 """Consolidation logic for merging agent outputs."""
 
-def consolidate(data):
-    """Consolidate data from multiple agents."""
-    return data
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable
+
+from . import classify
+
+Normalized = Dict[str, Any]
+
+
+def consolidate(results: Iterable[Normalized]) -> Dict[str, Any]:
+    """Consolidate data from multiple agents into the core schema.
+
+    Each element in ``results`` is expected to be a mapping containing at least
+    ``source`` and ``payload`` keys. The payload is merged into a single
+    structure, and ``meta`` information is recorded for every field capturing
+    the originating source and when the data was consolidated.
+    """
+
+    consolidated: Dict[str, Any] = {"meta": {}}
+    now = datetime.now(timezone.utc).isoformat()
+    sources: list[str] = []
+
+    for result in results:
+        source = result.get("source", "unknown")
+        payload = result.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        sources.append(source)
+        for key, value in payload.items():
+            consolidated[key] = value
+            consolidated["meta"][key] = {
+                "source": source,
+                "last_verified_at": now,
+            }
+
+    consolidated["meta"]["sources"] = sources
+    consolidated["meta"]["last_verified_at"] = now
+
+    # Add classification information based on the consolidated payload.
+    payload_only = {k: v for k, v in consolidated.items() if k != "meta"}
+    classification = classify.classify(payload_only)
+    if classification["wz2008"] or classification["gpt_tags"]:
+        consolidated["classification"] = classification
+        consolidated["meta"]["classification"] = {
+            "source": "classifier",
+            "last_verified_at": now,
+        }
+
+    return consolidated

--- a/tests/unit/test_classify.py
+++ b/tests/unit/test_classify.py
@@ -1,0 +1,22 @@
+"""Tests for classification utilities."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core.classify import classify
+
+
+def test_classify_basic():
+    data = {
+        "description": "We offer software consulting and retail services.",
+        "gpt_tags": ["AI", "SaaS"],
+    }
+    result = classify(data)
+    assert "62.01" in result["wz2008"]  # software
+    assert "70.22" in result["wz2008"]  # consulting
+    assert "47.19" in result["wz2008"]  # retail
+    # GPT tags merged with keyword tags
+    assert "AI" in result["gpt_tags"]
+    assert "software" in result["gpt_tags"]

--- a/tests/unit/test_consolidate.py
+++ b/tests/unit/test_consolidate.py
@@ -1,0 +1,29 @@
+"""Tests for consolidate utilities."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core.consolidate import consolidate
+
+
+def test_consolidate_merges_and_annotations():
+    results = [
+        {
+            "source": "agent1",
+            "payload": {"summary": "We develop software products."},
+        },
+        {
+            "source": "agent2",
+            "payload": {"companies": ["A", "B"]},
+        },
+    ]
+
+    combined = consolidate(results)
+
+    assert combined["summary"] == "We develop software products."
+    assert combined["companies"] == ["A", "B"]
+    assert combined["meta"]["summary"]["source"] == "agent1"
+    assert "last_verified_at" in combined["meta"]["summary"]
+    assert "62.01" in combined["classification"]["wz2008"]


### PR DESCRIPTION
## Summary
- add keyword-based WZ2008 and GPT tag classifier
- consolidate agent outputs with metadata and embedded classification
- add unit tests for classification and consolidation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a629b4a708832baeca702f7ca439c2