### PR TITLE
Implement GDPR anonymization and structured logging

### DIFF
--- a/compliance/gdpr.py
+++ b/compliance/gdpr.py
@@ -1,5 +1,70 @@
-"""GDPR compliance utilities."""
+"""GDPR compliance utilities.
 
-def anonymize(data):
-    """Remove non-public personal data."""
+This module provides helpers for removing or redacting non-public personal
+information ("PII") from arbitrary Python data structures.  The primary entry
+point is :func:`anonymize` which recursively traverses the provided object and
+removes common PII fields such as names, e‑mail addresses or phone numbers.
+
+The implementation is intentionally lightweight – it does not aim to cover
+every possible type of PII, but instead provides sensible defaults that are
+sufficient for unit tests and simple data structures.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+import re
+
+
+# Common keys that typically contain personal information.  Keys are matched in
+# a case-insensitive manner.
+SENSITIVE_KEYS = {
+    "name",
+    "email",
+    "phone",
+    "address",
+    "ssn",
+}
+
+# Regular expressions used to find e‑mail addresses and phone numbers inside
+# free-form text values.
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_RE = re.compile(r"\+?\d[\d\-\s()]{7,}\d")
+
+
+def _redact_string(value: str) -> str:
+    """Redact obvious personal information from a string."""
+
+    value = EMAIL_RE.sub("<redacted>", value)
+    value = PHONE_RE.sub("<redacted>", value)
+    return value
+
+
+def anonymize(data: Any) -> Any:
+    """Remove non-public personal data from ``data``.
+
+    The function accepts any Python object and returns a new object with common
+    personal information removed or redacted.  Dictionaries and lists are
+    traversed recursively.  Strings are scanned for e‑mail addresses and phone
+    numbers which are replaced with ``"<redacted>"``.
+    """
+
+    if isinstance(data, dict):
+        sanitized: dict[str, Any] = {}
+        for key, value in data.items():
+            if key.lower() in SENSITIVE_KEYS:
+                continue
+            sanitized[key] = anonymize(value)
+        return sanitized
+
+    if isinstance(data, list):
+        return [anonymize(item) for item in data]
+
+    if isinstance(data, str):
+        return _redact_string(data)
+
     return data
+
+
+__all__ = ["anonymize"]
+

--- a/logging/errors.py
+++ b/logging/errors.py
@@ -1,5 +1,93 @@
-"""Custom error definitions."""
+"""Custom error definitions and helpers.
+
+The workflow distinguishes between *soft* failures – errors that should be
+surfaced but do not necessarily abort the entire run – and *hard* failures that
+require human attention.  When a hard failure is instantiated an issue is
+created on GitHub (if the necessary configuration is available).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+import os
+
+import requests
+
 
 class A2AError(Exception):
     """Base error for A2A workflow."""
-    pass
+
+
+class SoftFailError(A2AError):
+    """A recoverable error that should be logged but does not halt execution."""
+
+
+class HardFailError(A2AError):
+    """An unrecoverable error.
+
+    On instantiation this error attempts to create a GitHub issue describing the
+    problem.  Failure to create an issue should not mask the original error so
+    all exceptions from the GitHub API are swallowed.
+    """
+
+    def __init__(self, message: str, *, title: Optional[str] = None, body: str = ""):
+        super().__init__(message)
+        self.issue_url = None
+        try:
+            self.issue_url = create_github_issue(title or message, body)
+        except Exception:
+            # We deliberately ignore errors here – the original exception is more
+            # important than the failure to file an issue.
+            self.issue_url = None
+
+
+def create_github_issue(
+    title: str,
+    body: str = "",
+    *,
+    repo: Optional[str] = None,
+    token: Optional[str] = None,
+) -> Optional[str]:
+    """Create a GitHub issue and return its URL.
+
+    Parameters
+    ----------
+    title:
+        Title of the issue.
+    body:
+        Body/description for the issue.
+    repo:
+        Target repository in ``owner/name`` form.  If omitted, the value of the
+        ``GITHUB_REPOSITORY`` environment variable is used.
+    token:
+        Personal access token or GitHub App token.  If omitted the function reads
+        ``GITHUB_TOKEN`` from the environment.
+
+    The function returns the URL of the created issue or ``None`` if the issue
+    could not be created (e.g. missing configuration).
+    """
+
+    repo = repo or os.getenv("GITHUB_REPOSITORY")
+    token = token or os.getenv("GITHUB_TOKEN")
+    if not repo or not token:
+        return None
+
+    url = f"https://api.github.com/repos/{repo}/issues"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    payload = {"title": title, "body": body}
+
+    response = requests.post(url, headers=headers, json=payload, timeout=10)
+    response.raise_for_status()
+    return response.json().get("html_url")
+
+
+__all__ = [
+    "A2AError",
+    "SoftFailError",
+    "HardFailError",
+    "create_github_issue",
+]
+

--- a/logging/logger.py
+++ b/logging/logger.py
@@ -1,6 +1,102 @@
-"""Logging utilities."""
+"""Structured JSON logging utilities.
 
-def get_logger():
-    """Return a stub logger."""
-    import logging
-    return logging.getLogger("a2a")
+This module exposes :func:`get_logger` which returns a standard library logger
+configured to emit JSON objects to stdout.  Each log record includes the
+``run_id`` and ``stage`` of the current workflow along with the log level and
+message.  The function is intentionally lightweight and has no external
+dependencies beyond the Python standard library.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Dict, Any
+import json
+import uuid
+import os
+import sys
+
+# Import the standard library logging module under a different name to avoid
+# confusing it with this package.
+import logging as _py_logging
+
+
+class JSONFormatter(_py_logging.Formatter):
+    """Format log records as JSON."""
+
+    def format(self, record: _py_logging.LogRecord) -> str:  # type: ignore[override]
+        payload: Dict[str, Any] = {
+            "run_id": getattr(record, "run_id", None),
+            "stage": getattr(record, "stage", None),
+            "level": record.levelname.lower(),
+            "message": record.getMessage(),
+        }
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        # Drop keys with ``None`` values to keep the output compact.
+        return json.dumps({k: v for k, v in payload.items() if v is not None})
+
+
+def get_logger(
+    run_id: Optional[str] = None,
+    stage: Optional[str] = None,
+    level: int = _py_logging.INFO,
+) -> _py_logging.Logger:
+    """Return a logger that emits JSON log records.
+
+    Parameters
+    ----------
+    run_id:
+        Identifier for the current workflow run.  If omitted, an attempt is made
+        to read ``RUN_ID`` from the environment or a random UUID is used.
+    stage:
+        Stage of the workflow emitting the logs.  If ``None`` the value of the
+        ``STAGE`` environment variable (if any) is used.
+    level:
+        Logging level to apply to the returned logger.
+    """
+
+    logger = _py_logging.getLogger("a2a")
+
+    if logger.handlers:
+        # Logger was already configured; still update contextual information.
+        # Any existing ``ContextFilter`` will update these values on subsequent
+        # records.
+        for flt in logger.filters:
+            if isinstance(flt, _ContextFilter):
+                flt.run_id = run_id or flt.run_id
+                flt.stage = stage or flt.stage
+        return logger
+
+    run_id = run_id or os.getenv("RUN_ID") or str(uuid.uuid4())
+    stage = stage or os.getenv("STAGE")
+
+    handler = _py_logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(JSONFormatter())
+
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    logger.propagate = False
+
+    context_filter = _ContextFilter(run_id=run_id, stage=stage)
+    logger.addFilter(context_filter)
+    return logger
+
+
+class _ContextFilter(_py_logging.Filter):
+    """Attach ``run_id`` and ``stage`` to log records."""
+
+    def __init__(self, run_id: Optional[str], stage: Optional[str]) -> None:
+        super().__init__()
+        self.run_id = run_id
+        self.stage = stage
+
+    def filter(self, record: _py_logging.LogRecord) -> bool:  # type: ignore[override]
+        record.run_id = self.run_id
+        record.stage = self.stage
+        return True
+
+
+__all__ = ["get_logger"]
+

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,36 @@
+"""Tests for custom error hierarchy."""
+
+import importlib.util
+import pathlib
+
+
+spec = importlib.util.spec_from_file_location(
+    "a2a_errors", pathlib.Path("logging/errors.py")
+)
+errors = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(errors)
+
+
+def test_hard_fail_creates_github_issue(monkeypatch):
+    called = {}
+
+    def fake_post(url, headers, json, timeout):  # noqa: D401 - simple stub
+        called["url"] = url
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"html_url": "https://github.com/example/repo/issues/1"}
+
+        return Response()
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "example/repo")
+    monkeypatch.setenv("GITHUB_TOKEN", "secret")
+    monkeypatch.setattr(errors.requests, "post", fake_post)
+
+    err = errors.HardFailError("Boom")
+
+    assert called["url"] == "https://api.github.com/repos/example/repo/issues"
+    assert err.issue_url == "https://github.com/example/repo/issues/1"
+

--- a/tests/unit/test_gdpr.py
+++ b/tests/unit/test_gdpr.py
@@ -1,0 +1,25 @@
+"""Tests for GDPR anonymisation helpers."""
+
+from compliance import gdpr
+
+
+def test_anonymize_removes_common_pii():
+    data = {
+        "name": "John Doe",
+        "email": "john@example.com",
+        "info": {
+            "phone": "+1-202-555-0143",
+            "note": "Reach me at john@example.com",
+        },
+    }
+
+    result = gdpr.anonymize(data)
+
+    # Top-level keys should be removed entirely
+    assert "name" not in result
+    assert "email" not in result
+
+    # Nested keys should also be removed and text should be redacted
+    assert "phone" not in result["info"]
+    assert result["info"]["note"] == "Reach me at <redacted>"
+

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,27 @@
+"""Tests for structured JSON logger."""
+
+import json
+import importlib.util
+import pathlib
+import logging
+
+
+spec = importlib.util.spec_from_file_location(
+    "a2a_logger", pathlib.Path("logging/logger.py")
+)
+logger_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(logger_module)
+
+
+def test_logger_emits_json_with_context(capfd):
+    logger = logger_module.get_logger(run_id="run123", stage="unit")
+    logger.info("hello world")
+
+    out, _ = capfd.readouterr()
+    payload = json.loads(out.strip())
+
+    assert payload["run_id"] == "run123"
+    assert payload["stage"] == "unit"
+    assert payload["level"] == "info"
+    assert payload["message"] == "hello world"
+


### PR DESCRIPTION
## Summary
- add GDPR anonymizer that strips common personal data and redacts text
- provide JSON logger emitting run ID, stage, and level
- define error hierarchy with GitHub issue creation for hard failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a632496728832ba8e4146029fb528c