### PR TITLE
docs: add architecture diagram and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Automated Agent-to-Agent (A2A) research workflow for company data enrichment, Hu
 
 This repository provides a skeleton implementation of the A2A research workflow. It orchestrates multiple research agents, consolidates their results, and produces PDF and CSV dossiers. HubSpot integration and Google Calendar/Contacts triggers are prepared but not yet fully implemented.
 
+## Architecture
+
+```mermaid
+flowchart LR
+    GC[Google Calendar] -->|triggers| O[Orchestrator]
+    GCo[Google Contacts] -->|triggers| O
+    O -->|dispatch| A[Research Agents]
+    A --> C[Consolidation]
+    C --> P[PDF/CSV]
+    C --> H[HubSpot]
+    P --> E[Email]
+```
+
 ## Setup Instructions
 
 1. Create and activate a Python 3.11 environment.
@@ -31,7 +44,29 @@ This repository provides a skeleton implementation of the A2A research workflow.
 python -m core.orchestrator
 ```
 
-This will poll Google services for triggers and send notification e‑mails (stubbed in tests).
+This will poll Google services for triggers and send notification e‑mails (stubbed in tests). Outputs are written to `output/exports`.
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `MAIL_SMTP_HOST` | SMTP server hostname | – |
+| `MAIL_SMTP_PORT` | SMTP server port | `587` |
+| `MAIL_USER` | SMTP username | – |
+| `MAIL_SMTP_PASS` | SMTP password | – |
+| `MAIL_FROM` | Sender e‑mail address | `MAIL_USER` |
+| `MAIL_SMTP_SECURE` | Use SSL for SMTP (`true`/`false`) | `true` |
+| `MAIL_TO` | Recipient e‑mail for reports | – |
+| `TRIGGER_WORDS_FILE` | Path to trigger words list | `config/trigger_words.txt` |
+| `GOOGLE_CREDENTIALS_JSON_BASE64` | Base64‑encoded Google credentials | – |
+| `GOOGLE_CALENDAR_ID` | Calendar ID to poll | `primary` |
+| `USE_PUSH_TRIGGERS` | Disable scheduled polling | `false` |
+| `ENABLE_PRO_SOURCES` | Allow pro research agents | `false` |
+| `ATTACH_PDF_TO_HUBSPOT` | Upload PDF to HubSpot | `true` |
+| `RUN_ID` | Identifier for logging | random UUID |
+| `STAGE` | Logging stage label | – |
+| `GITHUB_REPOSITORY` | Repository for error issues | – |
+| `GITHUB_TOKEN` | Token for GitHub issue creation | – |
 
 ## Repository Structure
 
@@ -39,8 +74,8 @@ Key directories:
 
 - `agents/` – individual research agents.
 - `core/` – orchestration, classification, consolidation, and feature flags.
-- `integrations/` – external service clients (HubSpot, Google, email).
-- `output/` – PDF and CSV rendering utilities.
+- `integrations/` – external service clients (HubSpot, Google, email) and templates.
+- `output/` – PDF and CSV rendering utilities and sample exports.
 - `schemas/` – JSON schema definitions.
 - `compliance/` – GDPR helpers.
 - `logging/` – logging utilities and error definitions.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,8 @@
 # Agents
 
-Contains modular research agents responsible for gathering company information from various sources. Each agent exposes a `run` function returning structured data.
+## Purpose
+Modular research agents gather company information from various sources. Each
+agent exposes a `run` function returning structured data.
 
 ## Files
 - `agent1_internal_company_research.py`: placeholder for internal research.
@@ -8,6 +10,9 @@ Contains modular research agents responsible for gathering company information f
 - `agent3_external_branch_research.py`: external branch research.
 - `agent4_external_customer_research.py`: external customer research.
 - `agent5_internal_customer_research.py`: internal customer research.
+
+## Dependencies
+Standard library only.
 
 ## Usage
 Agents are invoked by the orchestrator and share a common input/output schema.

--- a/compliance/README.md
+++ b/compliance/README.md
@@ -1,6 +1,13 @@
 # Compliance
 
+## Purpose
 Utilities for ensuring GDPR and other compliance requirements.
 
 ## Files
 - `gdpr.py`: anonymization helpers.
+
+## Dependencies
+None.
+
+## Usage
+Import `gdpr` functions where data needs anonymization before storage or transmission.

--- a/config/README.md
+++ b/config/README.md
@@ -1,9 +1,13 @@
 # Config
 
+## Purpose
 Configuration files for the workflow.
 
 ## Files
 - `trigger_words.txt`: newline-separated trigger words or phrases (case-insensitive).
+
+## Dependencies
+None.
 
 ## Usage
 Set the `TRIGGER_WORDS_FILE` environment variable to override the default location.

--- a/core/README.md
+++ b/core/README.md
@@ -1,5 +1,6 @@
 # Core
 
+## Purpose
 Core orchestration and helper modules that coordinate the overall workflow.
 
 ## Files
@@ -12,3 +13,6 @@ Core orchestration and helper modules that coordinate the overall workflow.
 
 ## Dependencies
 Standard Python libraries only in this skeleton.
+
+## Usage
+The orchestrator coordinates agents, consolidation, rendering, and notifications; invoke with `python -m core.orchestrator`.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,16 +1,19 @@
 # Integrations
 
+## Purpose
 Clients for external services such as HubSpot and Google APIs.
 
 ## Files
 - `hubspot_api.py`
-- `google_calendar.py`: scheduled polling of events with trigger-word
-  filtering and normalized payloads.
-- `google_contacts.py`: scheduled polling of contacts with trigger-word
-  filtering and normalized payloads.
+- `google_calendar.py`: scheduled polling of events with trigger-word filtering and normalized payloads.
+- `google_contacts.py`: scheduled polling of contacts with trigger-word filtering and normalized payloads.
 - `email_sender.py`: SMTP e-mail helper.
 - `web_scraper.py`
 - `sources_registry.py`
+- `templates/`: reusable e-mail templates.
 
-## External APIs
-These modules will later interface with respective APIs; currently stubs.
+## Dependencies
+`google-api-python-client`, `google-auth`, standard library SMTP.
+
+## Usage
+Modules are imported by the orchestrator or other components to interact with external services.

--- a/integrations/templates/README.md
+++ b/integrations/templates/README.md
@@ -1,0 +1,15 @@
+# Email Templates
+
+## Purpose
+Reusable templates for workflow notification e-mails.
+
+## Files
+- `email_subject.txt`: subject line for notification.
+- `email_body.txt`: plain-text body content.
+- `email_body.html`: HTML body content.
+
+## Dependencies
+None.
+
+## Usage
+Load the templates and substitute variables as needed before sending with `integrations.email_sender`.

--- a/integrations/templates/email_body.html
+++ b/integrations/templates/email_body.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Hello,</p>
+<p>Please find the attached report and data.</p>
+<p>Thanks,<br/>A2A Bot</p>
+</body>
+</html>

--- a/integrations/templates/email_body.txt
+++ b/integrations/templates/email_body.txt
@@ -1,0 +1,6 @@
+Hello,
+
+Please find the attached report and data.
+
+Thanks,
+A2A Bot

--- a/integrations/templates/email_subject.txt
+++ b/integrations/templates/email_subject.txt
@@ -1,0 +1,1 @@
+A2A Research Report Ready

--- a/logging/README.md
+++ b/logging/README.md
@@ -1,7 +1,14 @@
 # Logging
 
+## Purpose
 Logging utilities and error definitions.
 
 ## Files
 - `logger.py`
 - `errors.py`
+
+## Dependencies
+`requests` for GitHub issue creation.
+
+## Usage
+Import `logger.get_logger` to emit structured JSON logs and raise errors from `errors` for standardized handling.

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,5 +1,6 @@
 # Ops
 
+## Purpose
 Operational files for building, testing, and deploying the project.
 
 ## Files
@@ -8,3 +9,9 @@ Operational files for building, testing, and deploying the project.
 - `Makefile`
 - `CONFIG.md`
 - `SECURITY.md`
+
+## Dependencies
+Docker and Make are required for the provided workflows.
+
+## Usage
+Use the Makefile targets or Docker configurations to containerize and run the workflow.

--- a/output/README.md
+++ b/output/README.md
@@ -1,5 +1,6 @@
 # Output
 
+## Purpose
 Rendering utilities for PDF and CSV dossier generation.
 
 ## Files
@@ -8,6 +9,10 @@ Rendering utilities for PDF and CSV dossier generation.
 - `templates/pdf/`
 - `exports/pdf/`
 - `exports/csv/`
+- `examples/`: sample output files.
+
+## Dependencies
+`weasyprint` for PDF rendering and the Python standard library for CSV.
 
 ## Usage
 Modules are called with consolidated data to produce deliverables.

--- a/output/examples/README.md
+++ b/output/examples/README.md
@@ -1,0 +1,14 @@
+# Example Outputs
+
+## Purpose
+Sample PDF and CSV files demonstrating the expected dossier format.
+
+## Files
+- `sample_report.pdf`: minimal example report.
+- `sample_data.csv`: accompanying data export.
+
+## Dependencies
+None.
+
+## Usage
+Reference these files when designing integrations or testing output pipelines.

--- a/output/examples/sample_data.csv
+++ b/output/examples/sample_data.csv
@@ -1,0 +1,3 @@
+field,value
+name,Acme Corp
+website,https://acme.example

--- a/output/examples/sample_report.pdf
+++ b/output/examples/sample_report.pdf
@@ -1,0 +1,21 @@
+%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 72 72 Td (Sample PDF) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000197 00000 n 
+0000000298 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+360
+%%EOF

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,7 +1,14 @@
 # Schemas
 
+## Purpose
 JSON schema definitions for structured company data.
 
 ## Files
 - `company.core.schema.json`: core data model.
 - `views/`: derived views or projections.
+
+## Dependencies
+None.
+
+## Usage
+Validate JSON payloads against these schemas to ensure consistent structure.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,15 @@
 # Tests
 
+## Purpose
 Testing suite including unit, integration, and end-to-end tests.
 
-## Structure
+## Files
 - `unit/`: fast tests for individual functions.
 - `integration/`: tests across modules.
 - `e2e/`: end-to-end workflow tests.
+
+## Dependencies
+`pytest`.
+
+## Usage
+Run `pytest` from the repository root to execute all tests.


### PR DESCRIPTION
## Summary
- document system architecture and env vars in root README
- standardize subdirectory READMEs with purpose, files, dependencies, usage
- add sample PDF/CSV outputs and email templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6380db304832ba9f07db5c4f7ffdc