### PR TITLE
feat(ci): add GCP OIDC auth for deployments (no secrets)

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -1,0 +1,53 @@
+name: GCP Deploy (OIDC)
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to Google Cloud (OIDC)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github-pool/providers/github"
+          service_account: "gh-actions-deploy@<PROJECT_ID>.iam.gserviceaccount.com"
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: "<PROJECT_ID>"
+
+      - name: Verify identity
+        run: |
+          gcloud auth list --filter=status:ACTIVE --format="value(account)"
+          gcloud config list project
+
+      # Example: GCS Upload (if ./dist exists)
+      # - name: Upload to GCS
+      #   run: |
+      #     gsutil -m rsync -r ./dist gs://<BUCKET>/
+
+      # Example: Cloud Run Deploy (if Docker + service exists)
+      # - name: Build & Push to Artifact Registry
+      #   run: |
+      #     gcloud auth configure-docker ${REGION}-docker.pkg.dev --quiet
+      #     IMAGE=${REGION}-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/<SERVICE>:${{ github.sha }}
+      #     docker build -t "$IMAGE" .
+      #     docker push "$IMAGE"
+      # - name: Deploy to Cloud Run
+      #   run: |
+      #     gcloud run deploy <SERVICE> \
+      #       --image ${REGION}-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/<SERVICE>:${{ github.sha }} \
+      #       --region ${REGION} \
+      #       --platform managed \
+      #       --allow-unauthenticated

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Key directories:
 - `tests/` – unit, integration, and end-to-end tests.
 - `ops/` – operational files such as Dockerfile and CI/CD configs.
 - `config/` – configuration files such as trigger word list.
+## Deploy via GCP OIDC
+
+This repository includes a GitHub Actions workflow (`.github/workflows/gcp-deploy.yml`) that deploys to Google Cloud using Workload Identity Federation and requires no long-lived service account keys. Replace `<PROJECT_ID>` and `<PROJECT_NUMBER>` and optionally `<REGION>`, `<BUCKET>`, `<AR_REPO>`, `<SERVICE>` before use.
+
 
 ## License
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy to GCP using OIDC and Workload Identity Federation
- document GCP OIDC deployment workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76da4f598832bbec669e8a6257481