### PR TITLE
feat: integrate duplicate detection

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -15,4 +15,4 @@ Core orchestration and helper modules that coordinate the overall workflow.
 Standard Python libraries only in this skeleton.
 
 ## Usage
-The orchestrator coordinates agents, consolidation, rendering, and notifications; invoke with `python -m core.orchestrator`.
+The orchestrator coordinates agents, consolidation, duplicate detection, rendering, and notifications; invoke with `python -m core.orchestrator`.


### PR DESCRIPTION
## Summary
- integrate duplicate checker into orchestrator and skip processing when duplicates are found
- document duplicate detection in core README
- cover duplicate workflow with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7828fd4ac832b8b1f6fdafce54da5