### PR TITLE
Refine orchestration and add scheduled polling

### DIFF
--- a/core/consolidate.py
+++ b/core/consolidate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable
 
 from . import classify
 
@@ -11,39 +11,30 @@ Normalized = Dict[str, Any]
 
 
 def consolidate(results: Iterable[Normalized]) -> Dict[str, Any]:
-    """Consolidate data from multiple agents into a simple schema.
+    """Merge agent outputs into a flat structure and annotate sources."""
 
-    The result structure:
-    {
-      "payload": {...},          # merged keys from agents
-      "meta": {
-         "sources": [...],
-         "last_verified_at": "...iso..."
-      }
-    }
-    """
     now = datetime.now(timezone.utc).isoformat()
-    consolidated: Dict[str, Any] = {
-        "payload": {},
-        "meta": {"sources": [], "last_verified_at": now},
-    }
+    combined: Dict[str, Any] = {"meta": {}}
 
     for res in results or []:
         source = res.get("source") or "unknown"
-        consolidated["meta"]["sources"].append(source)
         payload = res.get("payload") or {}
-        # merge shallow keys
-        for k, v in payload.items():
-            # prefer first non-empty value
-            if k not in consolidated["payload"] or not consolidated["payload"][k]:
-                consolidated["payload"][k] = v
+        for key, value in payload.items():
+            if key not in combined or not combined.get(key):
+                combined[key] = value
+                combined["meta"][key] = {
+                    "source": source,
+                    "last_verified_at": now,
+                }
 
-    # Attach a lightweight classification based on keywords
-    classification = classify.classify(consolidated["payload"])
+    classification = classify.classify(combined)
     if classification:
-        consolidated["classification"] = classification
+        combined["classification"] = classification
 
-    # bubble up creator/recipient if present
-    consolidated["creator"] = consolidated["payload"].get("creator") or None
-    consolidated["recipient"] = consolidated["payload"].get("recipient") or None
-    return consolidated
+    combined["creator"] = combined.get("creator") or None
+    combined["recipient"] = combined.get("recipient") or None
+    return combined
+
+
+__all__ = ["consolidate"]
+

--- a/core/duplicate_check.py
+++ b/core/duplicate_check.py
@@ -2,7 +2,22 @@
 """Very small duplicate check helper."""
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, Optional
+
+
+def _extract_name(rec: Dict[str, Any]) -> Optional[str]:
+    payload = rec.get("payload") or {}
+    return rec.get("name") or payload.get("company_name") or payload.get("name")
+
+
+def _extract_website(rec: Dict[str, Any]) -> Optional[str]:
+    payload = rec.get("payload") or {}
+    return (
+        rec.get("website")
+        or rec.get("domain")
+        or payload.get("website")
+        or payload.get("domain")
+    )
 
 
 def is_duplicate(
@@ -10,21 +25,13 @@ def is_duplicate(
 ) -> bool:
     if not existing:
         return False
-    name = (record.get("payload") or {}).get("company_name") or (
-        record.get("payload") or {}
-    ).get("name")
-    website = (record.get("payload") or {}).get("website") or (
-        record.get("payload") or {}
-    ).get("domain")
+    name = (_extract_name(record) or "").lower()
+    website = (_extract_website(record) or "").lower()
     for r in existing:
-        rn = (r.get("payload") or {}).get("company_name") or (
-            r.get("payload") or {}
-        ).get("name")
-        rw = (r.get("payload") or {}).get("website") or (r.get("payload") or {}).get(
-            "domain"
-        )
-        if (name and rn and name.lower() == rn.lower()) or (
-            website and rw and website.lower() == rw.lower()
-        ):
+        rn = (_extract_name(r) or "").lower()
+        rw = (_extract_website(r) or "").lower()
+        if name and rn and name == rn:
+            return True
+        if website and rw and website == rw:
             return True
     return False

--- a/core/feature_flags.py
+++ b/core/feature_flags.py
@@ -1,4 +1,10 @@
 # core/feature_flags.py
 """Feature toggle flags."""
-USE_PUSH_TRIGGERS: bool = False
-ENABLE_PRO_SOURCES: bool = False
+
+import os
+
+USE_PUSH_TRIGGERS: bool = os.getenv("USE_PUSH_TRIGGERS", "0") == "1"
+ENABLE_PRO_SOURCES: bool = os.getenv("ENABLE_PRO_SOURCES", "0") == "1"
+ATTACH_PDF_TO_HUBSPOT: bool = os.getenv("ATTACH_PDF_TO_HUBSPOT", "1") == "1"
+
+__all__ = ["USE_PUSH_TRIGGERS", "ENABLE_PRO_SOURCES", "ATTACH_PDF_TO_HUBSPOT"]

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -42,9 +42,13 @@ def _retry(fn: Callable[[], Any], retries: int = 3, delay: float = 2.0) -> Any:
 def _normalize_events(events: Iterable[Dict[str, Any]]) -> List[Normalized]:
     norm: List[Normalized] = []
     for ev in events or []:
-        creator = (ev.get("creator") or {}).get("email") or ev.get("organizer", {}).get(
-            "email"
-        )
+        creator_info = ev.get("creator")
+        if isinstance(creator_info, dict):
+            creator = creator_info.get("email")
+        else:
+            creator = creator_info
+        if not creator:
+            creator = ev.get("organizer", {}).get("email")
         norm.append(
             {
                 "source": "calendar",
@@ -156,10 +160,10 @@ def run(
 
     # Guard against duplicates (best-effort)
     if duplicate_checker(consolidated, existing_records):
-        return {"status": "duplicate", "meta": consolidated.get("meta", {})}
+        return consolidated
 
     # Export artifacts
-    out_dir = Path(os.getenv("OUTPUT_DIR", "output"))
+    out_dir = Path(os.getenv("OUTPUT_DIR", "output")) / "exports"
     out_dir.mkdir(parents=True, exist_ok=True)
 
     pdf_path = out_dir / "report.pdf"
@@ -169,7 +173,8 @@ def run(
 
     # CRM + Email
     _retry(lambda: hubspot_upsert(consolidated))
-    _retry(lambda: hubspot_attach(pdf_path))
+    if feature_flags.ATTACH_PDF_TO_HUBSPOT:
+        _retry(lambda: hubspot_attach(pdf_path))
 
     def _send_email() -> None:
         sender = (
@@ -177,7 +182,8 @@ def run(
             or os.getenv("SMTP_FROM")
             or (os.getenv("SMTP_USER") or "")
         )
-        recipient = consolidated.get("creator") or os.getenv("MAIL_TO") or sender
+        data = consolidated if isinstance(consolidated, dict) else {}
+        recipient = data.get("creator") or os.getenv("MAIL_TO") or sender
         subject = f"A2A Research Report"
         body = "Attached report and data."
         email_sender.send_email(

--- a/integrations/email_sender.py
+++ b/integrations/email_sender.py
@@ -39,6 +39,8 @@ def send_email(
 ) -> None:
     """Send an email with optional attachments using SMTP/SSL or STARTTLS based on env settings."""
     cfg = _get_settings()
+    if not (os.getenv("EMAIL_SMTP_HOST") or os.getenv("SMTP_HOST")):
+        return
     msg = EmailMessage()
     msg["From"] = sender
     msg["To"] = recipient


### PR DESCRIPTION
## Summary
- support environment-based feature flags and optional HubSpot PDF attachment
- flatten consolidation results with metadata and improve duplicate detection
- add scheduled polling utilities for Google Calendar and Contacts and guard email sending when SMTP isn’t configured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a862947cb8832b9b11dc95fad83a8d