### PR TITLE
feat: enhance google integrations with validation and reminders

### DIFF
--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
   # Achtung: GitHub Actions läuft in UTC. Diese Cron deckt ca. 07–19 CET / 06–18 CEST ab (Mo–Fr, stündlich).
   schedule:
-    - cron: "0 6-18 * * 1-5"
+    - cron: "0 8-19 * * 1-5"
 
 permissions:
   contents: read

--- a/agents/templates.py
+++ b/agents/templates.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def build_reminder_email(source: str, recipient: str, missing: List[str]) -> Dict[str, str]:
+    """Build reminder e-mail in English and German for missing information."""
+    missing_list = ", ".join(missing)
+    subject = f"Information missing for new {source} entry"
+
+    body_en = (
+        "Hello,\n\n"
+        f"Some required information is missing in your new {source} entry.\n\n"
+        f"Missing fields: {missing_list}\n\n"
+        "Please update the entry and provide the missing details.\n\n"
+        "Thank you."
+    )
+
+    body_de = (
+        "Hallo,\n\n"
+        f"bei deinem neuen {source}-Eintrag fehlen wichtige Pflichtangaben.\n\n"
+        f"Fehlende Felder: {missing_list}\n\n"
+        "Bitte ergänze die fehlenden Informationen.\n\n"
+        "Vielen Dank."
+    )
+
+    return {
+        "recipient": recipient,
+        "subject": subject,
+        "body": body_en + "\n\n---\n\n" + body_de,
+    }

--- a/config/required_fields.json
+++ b/config/required_fields.json
@@ -1,0 +1,4 @@
+{
+  "calendar": ["company", "domain", "email", "phone"],
+  "contacts": ["company", "domain", "email", "phone"]
+}

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -10,15 +10,26 @@ special setup beyond the required secrets.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Sequence, Optional
+import importlib.util as _ilu
+import datetime as dt
 import os
 import time
 
 from core import consolidate, feature_flags, duplicate_check
 from integrations import google_calendar, google_contacts, hubspot_api, email_sender
 from output import pdf_render, csv_export
+
+# Local JSONL sink
+_JSONL_PATH = Path(__file__).resolve().parents[1] / "logging" / "jsonl_sink.py"
+_spec = _ilu.spec_from_file_location("jsonl_sink", _JSONL_PATH)
+_mod = _ilu.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(_mod)  # type: ignore[attr-defined]
+append_jsonl = _mod.append
+
+_LOG_PATH = Path("logs") / "workflows" / "reports.jsonl"
 
 Normalized = Dict[str, Any]
 
@@ -139,8 +150,10 @@ def run(
     consolidate_fn: Callable[[Iterable[Any]], Any] = consolidate.consolidate,
     pdf_renderer: Callable[[Any, Path], None] = pdf_render.render_pdf,
     csv_exporter: Callable[[Any, Path], None] = csv_export.export_csv,
-    hubspot_upsert: Callable[[Any], None] = hubspot_api.upsert_company,
+    hubspot_upsert: Callable[[Any], Optional[str]] = hubspot_api.upsert_company,
     hubspot_attach: Callable[[Path, str], None] = hubspot_api.attach_pdf,
+    hubspot_check_existing: Callable[[str], Optional[Dict[str, Any]]] = hubspot_api.check_existing_report,
+    company_id: Optional[str] = None,
     duplicate_checker: Callable[
         [Dict[str, Any], Optional[Iterable[Dict[str, Any]]]], bool
     ] = duplicate_check.is_duplicate,
@@ -178,13 +191,45 @@ def run(
     csv_exporter(consolidated, csv_path)
 
     # CRM + Email
-    _retry(lambda: hubspot_upsert(consolidated))
+    if company_id is None:
+        company_id = _retry(lambda: hubspot_upsert(consolidated))
+
     if (
         feature_flags.ATTACH_PDF_TO_HUBSPOT
         and os.getenv("HUBSPOT_ACCESS_TOKEN")
         and os.getenv("HUBSPOT_PORTAL_ID")
+        and company_id
     ):
-        _retry(lambda: hubspot_attach(pdf_path, "0"))
+        existing = hubspot_check_existing(company_id)
+        upload_required = False
+        if not existing:
+            upload_required = True
+        else:
+            created_str = existing.get("createdAt", "")
+            try:
+                created_at = dt.datetime.fromisoformat(created_str.replace("Z", "+00:00"))
+            except Exception:
+                upload_required = True
+            else:
+                if (dt.datetime.now(dt.timezone.utc) - created_at).days >= 7:
+                    upload_required = True
+
+        if upload_required:
+            _retry(lambda: hubspot_attach(pdf_path, company_id))
+            append_jsonl(
+                _LOG_PATH,
+                {"status": "report_uploaded", "company_id": company_id, "file": pdf_path.name},
+            )
+        else:
+            print(f"Skip upload: existing recent report for company {company_id}")
+            append_jsonl(
+                _LOG_PATH,
+                {
+                    "status": "report_skipped",
+                    "company_id": company_id,
+                    "reason": "existing recent report",
+                },
+            )
 
     def _send_email() -> None:
         sender = (
@@ -194,7 +239,7 @@ def run(
         )
         data = consolidated if isinstance(consolidated, dict) else {}
         recipient = data.get("creator") or os.getenv("MAIL_TO") or sender
-        subject = f"A2A Research Report"
+        subject = "A2A Research Report"
         body = "Attached report and data."
         email_sender.send_email(
             sender, recipient, subject, body, attachments=[pdf_path, csv_path]

--- a/core/parser.py
+++ b/core/parser.py
@@ -1,0 +1,21 @@
+import re
+from typing import Optional
+
+def extract_company(text: str) -> Optional[str]:
+    """Extract a company name using a simple heuristic.
+
+    Looks for patterns like ``Firma <Name>`` or ``Company: <Name>``. This is a
+    placeholder for later NER-based extraction.
+    """
+    match = re.search(r"(?:firma|company)[:\s]+([^\n]+)", text, re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return None
+
+def extract_domain(text: str) -> Optional[str]:
+    match = re.search(r"[a-zA-Z0-9.-]+\.[a-z]{2,}", text)
+    return match.group(0) if match else None
+
+def extract_phone(text: str) -> Optional[str]:
+    match = re.search(r"\+?\d[\d\s\/-]{7,}", text)
+    return match.group(0) if match else None

--- a/integrations/email_sender.py
+++ b/integrations/email_sender.py
@@ -113,3 +113,25 @@ def send_email(
             if cfg["user"]:
                 smtp.login(cfg["user"], cfg["password"])
             smtp.send_message(msg)
+
+
+def send(
+    *,
+    to: str,
+    subject: str,
+    body: str,
+    sender: Optional[str] = None,
+    attachments: Optional[Iterable[Path]] = None,
+    task_id: Optional[str] = None,
+) -> None:
+    """Convenience wrapper using environment defaults for the sender.
+
+    Parameters are passed to :func:`send_email` after determining the sender
+    address from environment variables (``MAIL_FROM``, ``SMTP_FROM`` or
+    ``SMTP_USER``).
+    """
+
+    sender_addr = sender or os.getenv("MAIL_FROM") or os.getenv("SMTP_FROM") or (
+        os.getenv("SMTP_USER") or ""
+    )
+    send_email(sender_addr, to, subject, body, attachments, task_id=task_id)

--- a/integrations/hubspot_api.py
+++ b/integrations/hubspot_api.py
@@ -41,7 +41,7 @@ def upsert_company(data: Dict[str, Any]) -> None:
 
 
 def check_existing_report(company_id: str) -> Optional[Dict[str, Any]]:
-    """Return latest report file for ``company_id`` if present."""
+    """Return latest report (id, name, createdAt) for ``company_id`` if present."""
     token = _token()
     if not token:
         return None

--- a/integrations/hubspot_api.py
+++ b/integrations/hubspot_api.py
@@ -40,6 +40,28 @@ def upsert_company(data: Dict[str, Any]) -> None:
         pass
 
 
+def check_existing_report(company_id: str) -> Optional[Dict[str, Any]]:
+    """Return latest report file for ``company_id`` if present."""
+    token = _token()
+    if not token:
+        return None
+
+    url = "https://api.hubapi.com/files/v3/files/search"
+    headers = {"Authorization": f"Bearer {token}"}
+    payload = {
+        "filters": [
+            {"propertyName": "name", "operator": "CONTAINS_TOKEN", "value": "report"},
+            {"propertyName": "companyId", "operator": "EQ", "value": company_id},
+        ],
+        "limit": 1,
+        "sorts": ["-createdAt"],
+    }
+    resp = requests.post(url, headers=headers, json=payload, timeout=30)
+    resp.raise_for_status()
+    results = resp.json().get("results", [])
+    return results[0] if results else None
+
+
 def attach_pdf(path: Path, company_id: str) -> Dict[str, str]:
     """Upload ``path`` to HubSpot and associate with a company."""
     token = _token()

--- a/tests/integration/test_google_apis.py
+++ b/tests/integration/test_google_apis.py
@@ -9,8 +9,13 @@ from integrations import google_calendar, google_contacts
 
 
 def test_calendar_scheduled_poll_integration(monkeypatch):
-    events = [{"creator": "alice@example.com", "summary": "Demo"}]
-    monkeypatch.setattr(google_calendar, "fetch_events", lambda: events)
+    event = {
+        "creator": {"email": "alice@example.com"},
+        "summary": "Demo",
+        "description": "Firma DemoCorp\ndemocorp.com\n+49 2222222",
+    }
+    monkeypatch.setattr(google_calendar, "fetch_events", lambda: [event])
+    monkeypatch.setattr(google_calendar.email_sender, "send", lambda *a, **k: None)
 
     result = google_calendar.scheduled_poll()
 
@@ -19,16 +24,31 @@ def test_calendar_scheduled_poll_integration(monkeypatch):
             "creator": "alice@example.com",
             "trigger_source": "calendar",
             "recipient": "alice@example.com",
-            "payload": events[0],
+            "payload": {
+                "title": "Demo",
+                "description": "Firma DemoCorp\ndemocorp.com\n+49 2222222",
+                "company": "DemoCorp",
+                "domain": "democorp.com",
+                "email": "alice@example.com",
+                "phone": "+49 2222222",
+                "notes_extracted": {
+                    "company": "DemoCorp",
+                    "domain": "democorp.com",
+                    "phone": "+49 2222222",
+                },
+            },
         }
     ]
 
 
 def test_contacts_scheduled_poll_integration(monkeypatch):
-    contacts = [
-        {"emailAddresses": [{"value": "bob@example.com"}], "names": [], "notes": ""}
-    ]
-    monkeypatch.setattr(google_contacts, "fetch_contacts", lambda: contacts)
+    contact = {
+        "emailAddresses": [{"value": "bob@example.com"}],
+        "names": [{"displayName": "Bob"}],
+        "notes": "Firma Bar Inc\nbar.com\n+49 3333333",
+    }
+    monkeypatch.setattr(google_contacts, "fetch_contacts", lambda: [contact])
+    monkeypatch.setattr(google_contacts.email_sender, "send", lambda *a, **k: None)
 
     result = google_contacts.scheduled_poll()
 
@@ -37,6 +57,17 @@ def test_contacts_scheduled_poll_integration(monkeypatch):
             "creator": "bob@example.com",
             "trigger_source": "contacts",
             "recipient": "bob@example.com",
-            "payload": contacts[0],
+            "payload": {
+                "names": ["Bob"],
+                "company": "Bar Inc",
+                "domain": "bar.com",
+                "email": "bob@example.com",
+                "phone": "+49 3333333",
+                "notes_extracted": {
+                    "company": "Bar Inc",
+                    "domain": "bar.com",
+                    "phone": "+49 3333333",
+                },
+            },
         }
     ]

--- a/tests/integration/test_workflow_outputs.py
+++ b/tests/integration/test_workflow_outputs.py
@@ -21,6 +21,7 @@ def test_orchestrator_generates_outputs_and_calls_hubspot(tmp_path, monkeypatch,
 
     def fake_upsert(data):
         calls["upsert"] += 1
+        return "123"
 
     def fake_attach(path, company_id):
         calls["attach"] += 1
@@ -47,6 +48,7 @@ def test_orchestrator_generates_outputs_and_calls_hubspot(tmp_path, monkeypatch,
         csv_exporter=csv_export.export_csv,
         hubspot_upsert=fake_upsert,
         hubspot_attach=fake_attach,
+        hubspot_check_existing=lambda cid: None,
     )
 
     out_dir = Path("output/exports")

--- a/tests/unit/test_hubspot_api.py
+++ b/tests/unit/test_hubspot_api.py
@@ -1,14 +1,25 @@
+import datetime as dt
 from pathlib import Path
+import sys
 
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core import orchestrator, feature_flags
 from integrations import hubspot_api
 
 
 class DummyResp:
-    def __init__(self, data):
+    def __init__(self, data, status=200):
         self._data = data
+        self.status_code = status
 
     def raise_for_status(self):
-        return None
+        if self.status_code >= 400:
+            from requests import HTTPError
+
+            raise HTTPError("boom")
 
     def json(self):
         return self._data
@@ -37,3 +48,111 @@ def test_attach_pdf(monkeypatch, tmp_path):
     result = hubspot_api.attach_pdf(pdf, "123")
     assert called["post"] and called["put"]
     assert result == {"file_id": "file123", "association_id": "assoc456"}
+
+
+def test_check_existing_report(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=30):
+        captured["json"] = json
+        return DummyResp({"results": [{"id": "1"}]})
+
+    monkeypatch.setattr(hubspot_api.requests, "post", fake_post)
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "tok")
+    result = hubspot_api.check_existing_report("123")
+    assert result == {"id": "1"}
+    assert captured["json"]["filters"][1]["value"] == "123"
+
+
+def test_check_existing_report_error(monkeypatch):
+    def fake_post(*a, **k):
+        return DummyResp({}, status=403)
+
+    monkeypatch.setattr(hubspot_api.requests, "post", fake_post)
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "tok")
+    with pytest.raises(Exception):
+        hubspot_api.check_existing_report("123")
+
+
+def _run_base(monkeypatch, tmp_path, check_result):
+    monkeypatch.setattr(feature_flags, "ATTACH_PDF_TO_HUBSPOT", True)
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("HUBSPOT_PORTAL_ID", "portal")
+    monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
+
+    called = {"attach": 0}
+
+    def fake_attach(path: Path, cid: str) -> None:
+        called["attach"] += 1
+
+    def fake_pdf(data, path):
+        path.write_text("pdf")
+
+    def fake_csv(data, path):
+        path.write_text("csv")
+
+    def fake_upsert(data):
+        return "123"
+
+    orchestrator.run(
+        triggers=[],
+        researchers=[],
+        consolidate_fn=lambda x: {},
+        pdf_renderer=fake_pdf,
+        csv_exporter=fake_csv,
+        hubspot_upsert=fake_upsert,
+        hubspot_attach=fake_attach,
+        hubspot_check_existing=lambda cid: check_result,
+        company_id=None,
+    )
+    return called["attach"]
+
+
+def test_run_uploads_when_no_report(monkeypatch, tmp_path):
+    assert _run_base(monkeypatch, tmp_path, None) == 1
+
+
+def test_run_skips_recent_report(monkeypatch, tmp_path):
+    recent = {"createdAt": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")}
+    assert _run_base(monkeypatch, tmp_path, recent) == 0
+
+
+def test_run_uploads_when_old_report(monkeypatch, tmp_path):
+    old = {
+        "createdAt": (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=8))
+        .isoformat()
+        .replace("+00:00", "Z")
+    }
+    assert _run_base(monkeypatch, tmp_path, old) == 1
+
+
+def test_run_propagates_check_error(monkeypatch, tmp_path):
+    def raise_err(cid):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(feature_flags, "ATTACH_PDF_TO_HUBSPOT", True)
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("HUBSPOT_PORTAL_ID", "portal")
+    monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
+
+    def fake_pdf(data, path):
+        path.write_text("pdf")
+
+    def fake_csv(data, path):
+        path.write_text("csv")
+
+    def fake_upsert(data):
+        return "123"
+
+    with pytest.raises(RuntimeError):
+        orchestrator.run(
+            triggers=[],
+            researchers=[],
+            consolidate_fn=lambda x: {},
+            pdf_renderer=fake_pdf,
+            csv_exporter=fake_csv,
+            hubspot_upsert=fake_upsert,
+            hubspot_attach=lambda p, c: None,
+            hubspot_check_existing=raise_err,
+        )
+

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -64,6 +64,7 @@ def test_run_pipeline_respects_feature_flags(monkeypatch):
 
     def fake_upsert(data):
         called["upsert"] += 1
+        return "123"
 
     def fake_attach(path, company_id):
         called["attach"] += 1
@@ -77,6 +78,7 @@ def test_run_pipeline_respects_feature_flags(monkeypatch):
         csv_exporter=fake_csv,
         hubspot_upsert=fake_upsert,
         hubspot_attach=fake_attach,
+        hubspot_check_existing=lambda cid: None,
     )
 
     assert called["basic"] == 1


### PR DESCRIPTION
## Summary
- add required field config and parser utilities for company, domain, phone extraction
- integrate logging, validation and reminder emails for Google Calendar and Contacts
- add reminder email templates and hourly weekday workflow schedule

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acb7b4ae04832ba71d4f5b863af3f6