### PR TITLE
Improve trigger word normalization and detection

### DIFF
--- a/config/trigger_words.txt
+++ b/config/trigger_words.txt
@@ -1,20 +1,14 @@
 research
-meeting preparation
-business customer
 recherche
-meeting-vorbereitung
-geschäftskunde
-besuchsvorbereitung
-briefing
-business client
-business customer
-geschäftskunde
 kundenrecherche
 customer research
+unternehmensrecherche
+business customer
+geschäftskunde
+business client
 meeting preparation
 meeting-vorbereitung
 meetingvorbereitung
-recherche
-research
 terminvorbereitung
-unternehmensrecherche
+besuchsvorbereitung
+briefing

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,19 @@
+import unicodedata
+
+def normalize_text(text: str) -> str:
+    if not text:
+        return ""
+    # Unicode normalisieren (Gedankenstrich etc. angleichen)
+    text = unicodedata.normalize("NFKC", text)
+    # Alles klein
+    text = text.lower()
+    # Alle Varianten von Bindestrichen vereinheitlichen
+    text = text.replace("–", "-").replace("—", "-").replace("‐", "-")
+    # Umlaute vereinheitlichen (optional für bessere Treffer)
+    text = (
+        text.replace("ä", "ae")
+            .replace("ö", "oe")
+            .replace("ü", "ue")
+            .replace("ß", "ss")
+    )
+    return text

--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -22,9 +22,15 @@ except Exception:  # pragma: no cover
     build = None  # type: ignore[assignment]
     HttpError = Exception  # type: ignore[assignment]
 
-from core.trigger_words import contains_trigger, load_trigger_words
+from core.trigger_words import load_trigger_words
+from core.utils import normalize_text
 from core import parser
 from . import email_sender
+
+
+def contains_trigger(text: str, trigger_words: list[str]) -> bool:
+    text = normalize_text(text)
+    return any(normalize_text(t) in text for t in trigger_words)
 
 # Local JSONL sink without clashing with stdlib logging
 _JSONL_PATH = Path(__file__).resolve().parents[1] / "logging" / "jsonl_sink.py"

--- a/integrations/google_contacts.py
+++ b/integrations/google_contacts.py
@@ -22,9 +22,15 @@ except Exception:  # pragma: no cover
     build = None  # type: ignore[assignment]
     HttpError = Exception  # type: ignore[assignment]
 
-from core.trigger_words import load_trigger_words, contains_trigger
+from core.trigger_words import load_trigger_words
 from core import feature_flags, summarize, parser
+from core.utils import normalize_text
 from . import email_sender
+
+
+def contains_trigger(text: str, trigger_words: list[str]) -> bool:
+    text = normalize_text(text)
+    return any(normalize_text(t) in text for t in trigger_words)
 
 # Local JSONL sink
 _JSONL_PATH = Path(__file__).resolve().parents[1] / "logging" / "jsonl_sink.py"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from integrations.google_calendar import contains_trigger
+
+
+def test_contains_trigger_case_insensitive():
+    assert contains_trigger("Meeting-Vorbereitung Dr. Willmar", ["meeting-vorbereitung"])
+
+
+def test_contains_trigger_unicode_dash():
+    assert contains_trigger("Meeting–Vorbereitung", ["meeting-vorbereitung"])
+
+
+def test_contains_trigger_compound():
+    assert contains_trigger("Terminvorbereitung für Kunde XY", ["terminvorbereitung"])
+
+
+def test_contains_trigger_umlaut():
+    assert contains_trigger("Kundenrecherche Schäfer", ["schaefer"])


### PR DESCRIPTION
## Summary
- add `normalize_text` utility to unify case, dashes and umlauts
- refactor Google Calendar and Contacts trigger checks to use normalized text
- clean trigger word list and add tests for normalization edge cases

## Testing
- `pytest tests/test_utils.py tests/unit/test_trigger_words.py tests/unit/test_google_polling.py`


------
https://chatgpt.com/codex/tasks/task_e_68accaa9769c832b94e38dfc6abb585f