### PR TITLE
Avoid exporting when no triggers detected

### DIFF
--- a/tests/e2e/test_orchestrator_e2e.py
+++ b/tests/e2e/test_orchestrator_e2e.py
@@ -29,5 +29,8 @@ def test_orchestrator_cli(tmp_path):
     subprocess.run(cmd, cwd=tmp_path, env=env, check=True)
 
     out_dir = Path(tmp_path) / "output/exports"
-    assert (out_dir / "report.pdf").exists()
-    assert (out_dir / "data.csv").exists()
+    assert not (out_dir / "report.pdf").exists()
+    assert not (out_dir / "data.csv").exists()
+    log_files = list((Path(tmp_path) / "logs" / "workflows").glob("*_workflow.jsonl"))
+    assert log_files, "log file missing"
+    assert '"status": "no_triggers"' in log_files[0].read_text()

--- a/tests/integration/test_workflow_outputs.py
+++ b/tests/integration/test_workflow_outputs.py
@@ -26,7 +26,14 @@ def test_orchestrator_generates_outputs_and_calls_hubspot(tmp_path, monkeypatch,
     def fake_attach(path, company_id):
         calls["attach"] += 1
 
-    triggers = []
+    triggers = [
+        {
+            "source": "calendar",
+            "creator": "alice@example.com",
+            "recipient": "alice@example.com",
+            "payload": {},
+        }
+    ]
 
     def researcher(trigger):
         return {

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,77 @@
+"""Tests for orchestrator guard behaviour and normal run."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core import orchestrator
+
+
+def _dummy_trigger():
+    return {
+        "source": "calendar",
+        "creator": "alice@example.com",
+        "recipient": "alice@example.com",
+        "payload": {},
+    }
+
+
+def test_run_exits_when_no_triggers(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(orchestrator, "gather_triggers", lambda *a, **k: [])
+
+    called = {"pdf": 0, "csv": 0}
+
+    def fake_pdf(data, path):
+        called["pdf"] += 1
+
+    def fake_csv(data, path):
+        called["csv"] += 1
+
+    monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
+
+    with pytest.raises(SystemExit) as exc:
+        orchestrator.run(pdf_renderer=fake_pdf, csv_exporter=fake_csv)
+
+    assert exc.value.code == 0
+    assert called == {"pdf": 0, "csv": 0}
+
+    log_dir = Path("logs/workflows")
+    files = list(log_dir.glob("*_workflow.jsonl"))
+    assert files, "log file not written"
+    content = files[0].read_text()
+    assert '"status": "no_triggers"' in content
+
+
+def test_run_processes_with_triggers(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
+
+    called = {"pdf": 0, "csv": 0}
+
+    def fake_pdf(data, path):
+        called["pdf"] += 1
+        path.write_text("pdf")
+
+    def fake_csv(data, path):
+        called["csv"] += 1
+        path.write_text("csv")
+
+    orchestrator.run(
+        triggers=[_dummy_trigger()],
+        researchers=[],
+        consolidate_fn=lambda x: {},
+        pdf_renderer=fake_pdf,
+        csv_exporter=fake_csv,
+        hubspot_upsert=lambda d: None,
+        hubspot_attach=lambda p, c: None,
+        hubspot_check_existing=lambda cid: None,
+    )
+
+    out_dir = Path("output/exports")
+    assert (out_dir / "report.pdf").exists()
+    assert (out_dir / "data.csv").exists()
+    assert called == {"pdf": 1, "csv": 1}

--- a/tests/unit/test_hubspot_api.py
+++ b/tests/unit/test_hubspot_api.py
@@ -10,6 +10,14 @@ from core import orchestrator, feature_flags
 from integrations import hubspot_api
 
 
+TRIGGER = {
+    "source": "calendar",
+    "creator": "alice@example.com",
+    "recipient": "alice@example.com",
+    "payload": {},
+}
+
+
 class DummyResp:
     def __init__(self, data, status=200):
         self._data = data
@@ -96,7 +104,7 @@ def _run_base(monkeypatch, tmp_path, check_result):
         return "123"
 
     orchestrator.run(
-        triggers=[],
+        triggers=[TRIGGER],
         researchers=[],
         consolidate_fn=lambda x: {},
         pdf_renderer=fake_pdf,
@@ -147,7 +155,7 @@ def test_run_propagates_check_error(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError):
         orchestrator.run(
-            triggers=[],
+            triggers=[TRIGGER],
             researchers=[],
             consolidate_fn=lambda x: {},
             pdf_renderer=fake_pdf,
@@ -178,7 +186,7 @@ def _run_no_upload(monkeypatch, tmp_path, upsert_return, pdf_write):
         path.write_text("csv")
 
     orchestrator.run(
-        triggers=[],
+        triggers=[TRIGGER],
         researchers=[],
         consolidate_fn=lambda x: {},
         pdf_renderer=fake_pdf,


### PR DESCRIPTION
## Summary
- exit orchestrator early when gather_triggers finds no matches
- log `no_triggers` runs to timestamped workflow JSONL files
- test coverage for early exit and normal trigger processing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68accf6511bc832bb4a99138768a1b94