### PR TITLE
Handle missing fields via reminders and add event deduplication

### DIFF
--- a/config/required_fields.json
+++ b/config/required_fields.json
@@ -1,4 +1,5 @@
 {
-  "calendar": ["company", "domain", "email", "phone"],
-  "contacts": ["company", "domain", "email", "phone"]
+  "calendar": ["company", "domain"],
+  "contacts": ["company", "domain"],
+  "optional": ["email", "phone"]
 }

--- a/integrations/email_reader.py
+++ b/integrations/email_reader.py
@@ -1,0 +1,112 @@
+"""IMAP email reader for replies to the Internal Research agent."""
+from __future__ import annotations
+
+import email
+import imaplib
+import os
+import re
+from email.header import decode_header
+from pathlib import Path
+from typing import Any, Dict, List
+import importlib.util as _ilu
+
+from core import parser
+
+_JSONL_PATH = Path(__file__).resolve().parents[1] / "logging" / "jsonl_sink.py"
+_spec = _ilu.spec_from_file_location("jsonl_sink", _JSONL_PATH)
+_mod = _ilu.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(_mod)
+append_jsonl = _mod.append
+
+_LOG_PATH = Path("logs") / "workflows" / "email_reader.jsonl"
+
+
+def _decode(value: str) -> str:
+    parts = decode_header(value)
+    decoded = ""
+    for part, charset in parts:
+        if isinstance(part, bytes):
+            decoded += part.decode(charset or "utf-8", errors="ignore")
+        else:
+            decoded += part
+    return decoded
+
+
+def fetch_replies() -> List[Dict[str, Any]]:
+    """Fetch unread replies and extract fields."""
+    host = os.getenv("IMAP_HOST")
+    port = int(os.getenv("IMAP_PORT", "993"))
+    user = os.getenv("IMAP_USER")
+    pwd = os.getenv("IMAP_PASS")
+    folder = os.getenv("IMAP_FOLDER", "INBOX")
+    if not all([host, user, pwd]):
+        raise RuntimeError("IMAP credentials not configured")
+
+    results: List[Dict[str, Any]] = []
+    imap = imaplib.IMAP4_SSL(host, port)
+    imap.login(user, pwd)
+    imap.select(folder)
+    typ, data = imap.search(None, "UNSEEN")
+    ids = data[0].split() if typ == "OK" else []
+    for msg_id in ids:
+        typ, msg_data = imap.fetch(msg_id, "(RFC822)")
+        if typ != "OK":
+            continue
+        msg = email.message_from_bytes(msg_data[0][1])
+        subject = _decode(msg.get("Subject", ""))
+        if not (
+            subject.startswith("[Agent: Internal Research]")
+            or subject.startswith("Missing Information for Your Research Request")
+        ):
+            continue
+        from_addr = email.utils.parseaddr(msg.get("From"))[1]
+        task_id = msg.get("In-Reply-To") or msg.get("References") or ""
+
+        body = ""
+        if msg.is_multipart():
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain" and not part.get("Content-Disposition"):
+                    try:
+                        body = part.get_payload(decode=True).decode(
+                            part.get_content_charset() or "utf-8", errors="ignore"
+                        )
+                    except Exception:
+                        body = ""
+                    break
+        else:
+            try:
+                body = msg.get_payload(decode=True).decode(
+                    msg.get_content_charset() or "utf-8", errors="ignore"
+                )
+            except Exception:
+                body = ""
+
+        fields: Dict[str, Any] = {}
+        company = parser.extract_company(body)
+        if company:
+            fields["company"] = company
+        domain = parser.extract_domain(body)
+        if domain:
+            fields["domain"] = domain
+        phone = parser.extract_phone(body)
+        if phone:
+            fields["phone"] = phone
+        mail_match = re.search(r"[\w.%-]+@[\w.-]+", body)
+        if mail_match:
+            fields["email"] = mail_match.group(0)
+
+        if fields:
+            results.append({"creator": from_addr, "task_id": task_id, "fields": fields})
+            append_jsonl(
+                _LOG_PATH,
+                {"status": "read", "from": from_addr, "task_id": task_id},
+            )
+        imap.store(msg_id, "+FLAGS", "(\\Seen)")
+
+    imap.logout()
+    return results
+
+
+__all__ = ["fetch_replies"]
+

--- a/tests/test_missing_fields.py
+++ b/tests/test_missing_fields.py
@@ -1,12 +1,10 @@
-import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
 from agents import agent_internal_search
-from core import orchestrator
+from core import orchestrator, utils
+from integrations import google_calendar
 
 
 @pytest.fixture(autouse=True)
@@ -23,6 +21,8 @@ def _stub_csv(data, path):
 
 
 def _trigger(payload):
+    payload = dict(payload)
+    payload.setdefault("id", "1")
     return {
         "source": "calendar",
         "creator": payload.get("email"),
@@ -36,12 +36,7 @@ def test_all_fields_present(monkeypatch):
     monkeypatch.setattr(agent_internal_search, "internal_run", lambda t: {"payload": {}})
     monkeypatch.setattr(agent_internal_search.email_sender, "send", lambda **k: send_called.__setitem__("rem", send_called["rem"] + 1))
     monkeypatch.setattr(agent_internal_search.email_sender, "send_email", lambda **k: None)
-    payload = {
-        "company": "ACME",
-        "domain": "acme.com",
-        "email": "a@b",
-        "phone": "1",
-    }
+    payload = {"company": "ACME", "domain": "acme.com", "email": "a@b", "phone": "1"}
     res = agent_internal_search.run(_trigger(payload))
     assert res.get("status") != "missing_fields"
     assert send_called["rem"] == 0
@@ -49,16 +44,16 @@ def test_all_fields_present(monkeypatch):
 
 def test_missing_field_triggers_reminder(monkeypatch):
     logs = []
-    orig = orchestrator.log_event
+    orig_log = orchestrator.log_event
+
     def capture(rec):
         logs.append(rec)
-        orig(rec)
+        orig_log(rec)
+
     monkeypatch.setattr(orchestrator, "log_event", capture)
     send_calls = []
-    def fake_send(**kw):
-        send_calls.append(kw)
     monkeypatch.setattr(agent_internal_search, "internal_run", lambda t: {"payload": {}})
-    monkeypatch.setattr(agent_internal_search.email_sender, "send", fake_send)
+    monkeypatch.setattr(agent_internal_search.email_sender, "send", lambda **kw: send_calls.append(kw))
     monkeypatch.setattr(agent_internal_search.email_sender, "send_email", lambda **k: None)
     trig = _trigger({"company": "ACME", "email": "a@b", "phone": "1"})
     with pytest.raises(SystemExit) as exc:
@@ -80,51 +75,66 @@ def test_missing_field_triggers_reminder(monkeypatch):
     assert '"status": "reminder_sent"' in content
 
 
-def test_multiple_missing_fields(monkeypatch):
-    captured = {}
-    def fake_send(**kw):
-        captured.update(kw)
-    monkeypatch.setattr(agent_internal_search.email_sender, "send", fake_send)
-    monkeypatch.setattr(agent_internal_search.email_sender, "send_email", lambda **k: None)
+def test_only_optional_missing(monkeypatch):
+    logs = []
     monkeypatch.setattr(agent_internal_search, "internal_run", lambda t: {"payload": {}})
-    trig = _trigger({"company": "ACME", "email": "a@b"})
-    res = agent_internal_search.run(trig)
-    assert res["status"] == "missing_fields"
-    assert set(res["missing"]) == {"domain", "phone"}
-    assert "Domain" in captured["body"] and "Phone" in captured["body"]
-    assert captured["sender"] == "research-agent@condata.io"
-
-
-def test_resume_after_update(monkeypatch):
-    send_called = {"rem": 0}
-    def fake_send(**kw):
-        send_called["rem"] += 1
-    called = {"internal": 0}
-    def stub_internal(t):
-        called["internal"] += 1
-        return {"payload": {}}
-    monkeypatch.setattr(agent_internal_search.email_sender, "send", fake_send)
+    monkeypatch.setattr(agent_internal_search.email_sender, "send", lambda **k: None)
     monkeypatch.setattr(agent_internal_search.email_sender, "send_email", lambda **k: None)
-    monkeypatch.setattr(agent_internal_search, "internal_run", stub_internal)
+
+    def capture(rec):
+        logs.append(rec)
+
+    monkeypatch.setattr(agent_internal_search, "_log_workflow", capture)
+    payload = {"company": "ACME", "domain": "acme.com"}
+    res = agent_internal_search.run(_trigger(payload))
+    assert res.get("status") != "missing_fields"
+    assert any(r.get("status") == "missing_optional_fields" for r in logs)
+
+
+def test_duplicate_event_skipped(monkeypatch):
+    monkeypatch.setattr(google_calendar, "load_trigger_words", lambda: ["Meet"])
+
+    def fake_events():
+        return [{"id": "e1", "iCalUID": "e1", "updated": "u1", "summary": "Meet ACME", "description": ""}]
+
+    monkeypatch.setattr(google_calendar, "_calendar_ids", lambda cid: ["primary"])
+
+    class FakeReq:
+        def events(self):
+            return self
+
+        def list(self, **kw):
+            return self
+
+        def execute(self):
+            return {"items": fake_events()}
+
+    monkeypatch.setattr(google_calendar, "_service", lambda: FakeReq())
+    utils.mark_processed("e1", "u1", Path("logs/processed_events.jsonl"))
+    events = google_calendar.fetch_events()
+    assert events == []
+    content = Path("logs/workflows/calendar.jsonl").read_text()
+    assert '"status": "skipped"' in content
+
+
+def test_email_reply_resumes(monkeypatch):
+    called = {"internal": 0}
+    monkeypatch.setattr(
+        agent_internal_search,
+        "internal_run",
+        lambda t: (called.__setitem__("internal", called["internal"] + 1) or {"payload": {}}),
+    )
+    monkeypatch.setattr(agent_internal_search.email_sender, "send", lambda **k: None)
+    monkeypatch.setattr(agent_internal_search.email_sender, "send_email", lambda **k: None)
     monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
-    # first run with missing domain
-    trig1 = _trigger({"company": "ACME", "email": "a@b", "phone": "1"})
-    with pytest.raises(SystemExit):
-        orchestrator.run(
-            triggers=[trig1],
-            researchers=[agent_internal_search.run],
-            pdf_renderer=_stub_pdf,
-            csv_exporter=_stub_csv,
-            hubspot_upsert=lambda d: None,
-            hubspot_attach=lambda p, c: None,
-            hubspot_check_existing=lambda cid: None,
-        )
-    assert called["internal"] == 0
-    assert send_called["rem"] == 1
-    # second run with all fields
-    trig2 = _trigger({"company": "ACME", "domain": "acme.com", "email": "a@b", "phone": "1"})
+    monkeypatch.setattr(
+        orchestrator.email_reader,
+        "fetch_replies",
+        lambda: [{"creator": "a@b", "task_id": "1", "fields": {"domain": "acme.com"}}],
+    )
+    trig = _trigger({"company": "ACME", "email": "a@b", "phone": "1"})
     orchestrator.run(
-        triggers=[trig2],
+        triggers=[trig],
         researchers=[agent_internal_search.run],
         consolidate_fn=lambda x: {},
         pdf_renderer=_stub_pdf,
@@ -134,4 +144,30 @@ def test_resume_after_update(monkeypatch):
         hubspot_check_existing=lambda cid: None,
     )
     assert called["internal"] == 1
-    assert send_called["rem"] == 1
+    content = "".join(f.read_text() for f in Path("logs/workflows").glob("*.jsonl"))
+    assert '"status": "resumed"' in content
+
+
+def test_irrelevant_email_ignored(monkeypatch):
+    monkeypatch.setattr(agent_internal_search, "internal_run", lambda t: {"payload": {}})
+    monkeypatch.setattr(agent_internal_search.email_sender, "send", lambda **k: None)
+    monkeypatch.setattr(agent_internal_search.email_sender, "send_email", lambda **k: None)
+    monkeypatch.setattr(
+        orchestrator.email_reader,
+        "fetch_replies",
+        lambda: [{"creator": "a@b", "task_id": "999", "fields": {"domain": "x.com"}}],
+    )
+    trig = _trigger({"company": "ACME", "email": "a@b", "phone": "1"})
+    with pytest.raises(SystemExit):
+        orchestrator.run(
+            triggers=[trig],
+            researchers=[agent_internal_search.run],
+            pdf_renderer=_stub_pdf,
+            csv_exporter=_stub_csv,
+            hubspot_upsert=lambda d: None,
+            hubspot_attach=lambda p, c: None,
+            hubspot_check_existing=lambda cid: None,
+        )
+    content = "".join(f.read_text() for f in Path("logs/workflows").glob("*.jsonl"))
+    assert '"status": "pending"' in content
+


### PR DESCRIPTION
## Summary
- validate required vs optional fields from config and send friendly reminder emails
- resume pending tasks from IMAP replies and log pending/resumed states
- deduplicate calendar and contact items and improve company extraction from event titles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acea9dfd58832ba57c1cd219cbc254