### PR TITLE
Improve reminder emails and event handling

### DIFF
--- a/tests/integration/test_google_apis.py
+++ b/tests/integration/test_google_apis.py
@@ -10,12 +10,13 @@ from integrations import google_calendar, google_contacts
 
 def test_calendar_scheduled_poll_integration(monkeypatch):
     event = {
+        "id": "e1",
         "creator": {"email": "alice@example.com"},
         "summary": "Demo",
         "description": "Firma DemoCorp\ndemocorp.com\n+49 2222222",
     }
     monkeypatch.setattr(google_calendar, "fetch_events", lambda: [event])
-    monkeypatch.setattr(google_calendar.email_sender, "send", lambda *a, **k: None)
+    monkeypatch.setattr(google_calendar.email_sender, "send_reminder", lambda **k: None)
 
     result = google_calendar.scheduled_poll()
 
@@ -36,6 +37,9 @@ def test_calendar_scheduled_poll_integration(monkeypatch):
                     "domain": "democorp.com",
                     "phone": "+49 2222222",
                 },
+                "event_id": "e1",
+                "start": None,
+                "end": None,
             },
         }
     ]

--- a/tests/unit/test_google_polling.py
+++ b/tests/unit/test_google_polling.py
@@ -12,12 +12,13 @@ from core import trigger_words  # noqa: E402
 
 def test_calendar_scheduled_poll_normalizes(monkeypatch):
     event = {
+        "id": "e1",
         "creator": {"email": "alice@example.com"},
         "summary": "Meeting",
         "description": "Firma TestCorp\nwww.testcorp.com\n+49 1234567",
     }
     monkeypatch.setattr(google_calendar, "fetch_events", lambda: [event])
-    monkeypatch.setattr(google_calendar.email_sender, "send", lambda *a, **k: None)
+    monkeypatch.setattr(google_calendar.email_sender, "send_reminder", lambda **k: None)
 
     result = google_calendar.scheduled_poll()
 
@@ -38,6 +39,9 @@ def test_calendar_scheduled_poll_normalizes(monkeypatch):
                     "domain": "www.testcorp.com",
                     "phone": "+49 1234567",
                 },
+                "event_id": "e1",
+                "start": None,
+                "end": None,
             },
         }
     ]


### PR DESCRIPTION
## Summary
- extract company names after trigger words and normalize calendar events
- send reminder emails with full event context, unique task IDs, and logging
- poll IMAP for replies to `[Research Agent] Missing Information` reminders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad32135d24832ba0e5542bbc5fdba7