### PR TITLE
Include workflow logs in outputs artifact

### DIFF
--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -119,5 +119,6 @@ jobs:
           name: outputs
           path: |
             output/**
+            logs/workflows/**
             **/*.pdf
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- upload `logs/workflows/**` alongside existing outputs in run-orchestrator job

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef08b3c54832b9d436da2c9b44605