### PR TITLE
Add severity-based logging and automated issue workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,11 @@
+labels:
+  - name: bug
+    color: cc0000
+  - name: auto-created
+    color: ffffff
+  - name: error:reminder
+    color: d73a4a
+  - name: error:mail
+    color: d73a4a
+  - name: error:report
+    color: d73a4a

--- a/.github/workflows/auto-issues.yml
+++ b/.github/workflows/auto-issues.yml
@@ -1,0 +1,132 @@
+name: Auto Create Issues from Logs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *"
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  scan-logs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Parse logs and create/update issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            const runNumber = Number(process.env.GITHUB_RUN_NUMBER);
+            const logDir = path.join(process.env.GITHUB_WORKSPACE, "logs/workflows");
+            if (!fs.existsSync(logDir)) {
+              console.log("No logs directory found → skip.");
+              return;
+            }
+            const files = fs.readdirSync(logDir).filter(f => f.endsWith(".jsonl"));
+            const seen = new Set();
+
+            const markerFor = (n) => `<!-- last_seen_run: ${n} -->`;
+
+            for (const file of files) {
+              const lines = fs.readFileSync(path.join(logDir, file), "utf-8").trim().split("\n");
+              for (const line of lines) {
+                let entry;
+                try { entry = JSON.parse(line); } catch { continue; }
+
+                if (!(entry.status && entry.status.endsWith("_error") && entry.severity === "critical")) continue;
+
+                const errorType = entry.status;
+                seen.add(errorType);
+                const errorMsg = (entry.error || "").split("\n")[0];
+                const issueTitle = `🐛 ${errorType} – ${errorMsg}`;
+
+                const issueBody = `
+### Problem
+Detected status: \`${errorType}\`
+
+### Context
+- **Workflow ID:** ${entry.workflow_id || "n/a"}
+- **Event/Contact ID:** ${entry.event_id || entry.contact_id || "n/a"}
+- **Source:** ${entry.trigger_source || "unknown"}
+- **Error:** ${entry.error || "n/a"}
+- **Run Link:** ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}
+
+### Raw Log
+\`\`\`json
+${JSON.stringify(entry, null, 2)}
+\`\`\`
+
+---
+
+Auto-created by GitHub Action.
+${markerFor(runNumber)}
+`;
+
+                const issues = await github.rest.issues.listForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: "open",
+                  labels: "bug,auto-created"
+                });
+
+                const existing = issues.data.find(i => i.title.startsWith(`🐛 ${errorType}`));
+                if (existing) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: existing.number,
+                    body: `⚠️ ${errorType} detected again in workflow ${entry.workflow_id}\n\n\`\`\`json\n${JSON.stringify(entry, null, 2)}\n\`\`\``
+                  });
+
+                  const updatedBody = (existing.body || "").replace(/<!-- last_seen_run: \d+ -->/, markerFor(runNumber));
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: existing.number,
+                    body: updatedBody
+                  });
+                } else {
+                  await github.rest.issues.create({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    title: issueTitle,
+                    body: issueBody,
+                    labels: ["bug", "auto-created", `error:${errorType}`]
+                  });
+                }
+              }
+            }
+
+            const openIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "bug,auto-created"
+            });
+
+            for (const issue of openIssues.data) {
+              const match = issue.body && issue.body.match(/last_seen_run: (\d+)/);
+              const last = match ? Number(match[1]) : runNumber;
+              if (runNumber - last >= 10 && !seen.has(issue.title.slice(2).split(" – ")[0])) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: "✅ No occurrences in the last 10 workflow runs. Auto-closing."
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: "closed"
+                });
+              }
+            }

--- a/integrations/email_reader.py
+++ b/integrations/email_reader.py
@@ -134,7 +134,10 @@ def poll_replies(interval: int = 600) -> None:
         try:
             fetch_replies()
         except Exception as e:
-            append_jsonl(_REPLY_LOG, {"status": "error", "error": str(e)})
+            append_jsonl(
+                _REPLY_LOG,
+                {"status": "error", "error": str(e), "severity": "warning"},
+            )
         time.sleep(interval)
 
 

--- a/integrations/email_sender.py
+++ b/integrations/email_sender.py
@@ -41,7 +41,8 @@ def send(
         log_step(
             "orchestrator",
             "mail_error",
-            {"to": to, "subject": subject, "error": str(e)},
+            {"to": to, "subject": subject, "error": str(e), "event_id": task_id},
+            severity="critical",
         )
         raise
 
@@ -70,7 +71,8 @@ def send_email(
         log_step(
             "orchestrator",
             "mail_error",
-            {"to": to, "subject": subject, "error": str(e)},
+            {"to": to, "subject": subject, "error": str(e), "event_id": task_id},
+            severity="critical",
         )
         raise
 

--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -288,6 +288,7 @@ def scheduled_poll(fetch_fn: Optional[Callable[[], List[Dict[str, Any]]]] = None
                 "calendar",
                 "reminder_error",
                 {"event_id": payload.get("event_id"), "error": str(e)},
+                severity="critical",
             )
 
         log_step(

--- a/integrations/google_contacts.py
+++ b/integrations/google_contacts.py
@@ -186,6 +186,7 @@ def scheduled_poll(fetch_fn: Optional[Callable[[], List[Dict[str, Any]]]] = None
                 "contacts",
                 "reminder_error",
                 {"contact_id": contact_id, "error": str(e)},
+                severity="critical",
             )
 
         log_step(


### PR DESCRIPTION
## Summary
- track warning and critical severities in workflow logs and digest
- log reminder, mail, and report failures with severity and workflow context
- periodically convert critical log entries into GitHub issues with dedupe and auto-closing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af14d8b104832b95c41c5c0a8c0945