### PR TITLE
fix: correct smtp self-test arguments

### DIFF
--- a/.github/workflows/smtp_selftest.yml
+++ b/.github/workflows/smtp_selftest.yml
@@ -35,10 +35,8 @@ jobs:
       - name: Send test mail
         run: |
           python - <<'PY'
-          import os
           from integrations.email_sender import send_email
           send_email(
-              os.environ["MAIL_FROM"],
               "${{ github.event.inputs.recipient }}",
               "${{ github.event.inputs.subject }}",
               "${{ github.event.inputs.body }}"


### PR DESCRIPTION
## Summary
- fix send_email call in smtp self-test workflow to use three parameters
- clean up unused MAIL_FROM argument

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af214b7878832b90665a967580b899