### PR TITLE
Fix workflow YAML syntax and enable manual runs

### DIFF
--- a/.github/workflows/auto-issues.yml
+++ b/.github/workflows/auto-issues.yml
@@ -49,26 +49,26 @@ jobs:
                 const issueTitle = `🐛 ${errorType} – ${errorMsg}`;
 
                 const issueBody = `
-### Problem
-Detected status: \`${errorType}\`
-
-### Context
-- **Workflow ID:** ${entry.workflow_id || "n/a"}
-- **Event/Contact ID:** ${entry.event_id || entry.contact_id || "n/a"}
-- **Source:** ${entry.trigger_source || "unknown"}
-- **Error:** ${entry.error || "n/a"}
-- **Run Link:** ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}
-
-### Raw Log
-\`\`\`json
-${JSON.stringify(entry, null, 2)}
-\`\`\`
-
----
-
-Auto-created by GitHub Action.
-${markerFor(runNumber)}
-`;
+                ### Problem
+                Detected status: \`${errorType}\`
+                
+                ### Context
+                - **Workflow ID:** ${entry.workflow_id || "n/a"}
+                - **Event/Contact ID:** ${entry.event_id || entry.contact_id || "n/a"}
+                - **Source:** ${entry.trigger_source || "unknown"}
+                - **Error:** ${entry.error || "n/a"}
+                - **Run Link:** ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}
+                
+                ### Raw Log
+                \`\`\`json
+                ${JSON.stringify(entry, null, 2)}
+                \`\`\`
+                
+                ---
+                
+                Auto-created by GitHub Action.
+                ${markerFor(runNumber)}
+                `;
 
                 const issues = await github.rest.issues.listForRepo({
                   owner: context.repo.owner,

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,16 +1,36 @@
- name: CI
-@@
- jobs:
-   build:
-     runs-on: ubuntu-latest
-     timeout-minutes: 15
-+    env:
-+      # stabile Defaults für Unit-Tests (keine echten Außenbindungen)
-+      TRIGGER_WORDS_FILE: tests/fixtures/triggers.txt
-+      SMTP_HOST: localhost
-+      SMTP_PORT: 2525
-+      MAIL_FROM: ci@example.test
-@@
-       - name: Run tests
--        run: pytest
-+        run: pytest -q
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # stabile Defaults für Unit-Tests (keine echten Außenbindungen)
+      TRIGGER_WORDS_FILE: tests/fixtures/triggers.txt
+      SMTP_HOST: localhost
+      SMTP_PORT: 2525
+      MAIL_FROM: ci@example.test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- restore valid structure in ci_cd workflow and add manual trigger
- clean up auto-issues workflow indentation so YAML parses

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/a2a.yml')"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/auto-issues.yml')"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci_cd.yml')"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/live_e2e.yml')"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/smtp_selftest.yml')"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afd05b4480832ba47ae2b0d6baa548