### PR TITLE
Use timezone-aware UTC timestamps

### DIFF
--- a/agents/agent_internal_search.py
+++ b/agents/agent_internal_search.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -29,7 +29,7 @@ def _log_agent(
     action: str, domain: str, user_email: str, artifacts: str | None = None
 ) -> None:
     """Write a log line for this agent."""
-    date = datetime.utcnow()
+    date = datetime.now(timezone.utc)
     path = (
         Path("logs")
         / "agent_internal_search"
@@ -38,7 +38,7 @@ def _log_agent(
         / f"{date:%d}.jsonl"
     )
     record = {
-        "ts_utc": date.isoformat() + "Z",
+        "ts_utc": date.isoformat().replace("+00:00", "Z"),
         "agent": "agent_internal_search",
         "action": action,
         "company_domain": domain,
@@ -50,11 +50,11 @@ def _log_agent(
 
 
 def _log_workflow(record: Dict[str, Any]) -> None:
-    ts = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
     path = Path("logs") / "workflows" / f"{ts}_workflow.jsonl"
     data = dict(record)
     data.setdefault(
-        "timestamp", datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+        "timestamp", datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     )
     append_jsonl(path, data)
 
@@ -168,7 +168,7 @@ def run(trigger: Normalized) -> Normalized:
             lr = last_report_date.replace("Z", "+00:00")
             last_dt = datetime.fromisoformat(str(lr))
             # Compare against current UTC time
-            days_since_report = (datetime.utcnow() - last_dt.replace(tzinfo=None)).days
+            days_since_report = (datetime.now(timezone.utc) - last_dt).days
         except Exception:
             days_since_report = None
             last_dt = None

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -41,10 +41,13 @@ def log_event(record: Dict[str, Any]) -> None:
     appends the provided record.
     """
 
-    ts = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
     path = Path("logs") / "workflows" / f"{ts}_workflow.jsonl"
     record = dict(record)
-    record.setdefault("timestamp", datetime.utcnow().replace(microsecond=0).isoformat() + "Z")
+    record.setdefault(
+        "timestamp",
+        datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    )
     record.setdefault("severity", "info")
     record.setdefault("workflow_id", get_workflow_id())
     append_jsonl(path, record)

--- a/core/task_history.py
+++ b/core/task_history.py
@@ -6,7 +6,7 @@ Records events related to tasks such as reminders or escalations. The
 history shares the same SQLite database as :mod:`core.tasks`.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 import sqlite3
 
 from . import tasks
@@ -29,7 +29,7 @@ def _connect() -> sqlite3.Connection:
 
 def record_event(task_id: str, event: str) -> None:
     """Record a history ``event`` for ``task_id`` with the current timestamp."""
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     with _connect() as conn:
         conn.execute(
             "INSERT INTO task_history VALUES (?, ?, ?)",

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -12,7 +12,7 @@ compatible with both we honour ``TASKS_DB_URL`` when present and fall back to
 """
 
 from dataclasses import dataclass, asdict
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import os
 import sqlite3
@@ -43,7 +43,7 @@ def _log_action(action: str, task: Dict[str, Any]) -> None:
         "task_id": task.get("id"),
         "status": task.get("status"),
         "assigned_to": task.get("employee_email"),
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     logger.info(json.dumps(payload))
 
@@ -92,7 +92,7 @@ def create_task(
     missing_fields: Any,
     employee_email: str,
 ) -> Dict[str, Any]:
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     task = Task(
         id=str(uuid.uuid4()),
         trigger=trigger,
@@ -141,7 +141,7 @@ def get_task(task_id: str) -> Optional[Dict[str, Any]]:
 
 
 def update_task_status(task_id: str, status: str) -> Optional[Dict[str, Any]]:
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     with _connect() as conn:
         conn.execute(
             'UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?',

--- a/core/utils.py
+++ b/core/utils.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import unicodedata
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import lru_cache
 from logging import getLogger
 from pathlib import Path
@@ -35,7 +35,7 @@ def get_workflow_id() -> str:
     """Return a unique workflow identifier for the current run."""
     global WORKFLOW_ID, SUMMARY
     if WORKFLOW_ID is None:
-        WORKFLOW_ID = f"wf-{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:6]}"
+        WORKFLOW_ID = f"wf-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:6]}"
         SUMMARY = {
             "events_detected": 0,
             "contacts_detected": 0,


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` calls with timezone-aware `datetime.now(timezone.utc)`
- ensure consistent UTC formatting in logs and workflow IDs

## Testing
- `pytest`
- `pytest tests/e2e/test_orchestrator_e2e.py`


------
https://chatgpt.com/codex/tasks/task_e_68b002301cb8832baff77debdd0dbb42