### PR TITLE
feat: improve mailer resilience and attachment handling

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/integrations/mailer.py
+++ b/integrations/mailer.py
@@ -4,6 +4,10 @@
 from __future__ import annotations
 
 from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email.mime.base import MIMEBase
+from email import encoders
+from pathlib import Path
 import smtplib
 import ssl
 
@@ -18,6 +22,7 @@ def send_email(
     subject: str,
     body: str,
     secure: str = "ssl",
+    attachments: list[str] | None = None,
 ) -> None:
     """Send an e-mail via SMTP using the selected security mode.
 
@@ -26,12 +31,27 @@ def send_email(
     host, port, user, password, mail_from: SMTP connection details.
     to, subject, body: Message details.
     secure: ``"ssl"`` or ``"tls"`` (STARTTLS).
+    attachments: optional list of file paths to include.
     """
 
-    msg = MIMEText(body, "plain", "utf-8")
+    msg = MIMEMultipart()
+    msg.attach(MIMEText(body, "plain", "utf-8"))
     msg["From"] = mail_from
     msg["To"] = to
     msg["Subject"] = subject
+
+    for path in attachments or []:
+        p = Path(path)
+        try:
+            with p.open("rb") as fh:
+                part = MIMEBase("application", "octet-stream")
+                part.set_payload(fh.read())
+            encoders.encode_base64(part)
+            part.add_header("Content-Disposition", f'attachment; filename="{p.name}"')
+            msg.attach(part)
+        except Exception:
+            # Skip unreadable attachment – higher level already logged
+            continue
 
     try:
         if secure == "ssl":

--- a/tests/test_missing_fields.py
+++ b/tests/test_missing_fields.py
@@ -55,19 +55,17 @@ def test_missing_field_triggers_reminder(monkeypatch):
     monkeypatch.setattr(agent_internal_search, "internal_run", lambda t: {"payload": {}})
     monkeypatch.setattr(agent_internal_search.email_sender, "send", lambda **kw: send_calls.append(kw))
     monkeypatch.setattr(agent_internal_search.email_sender, "send_email", lambda **k: None)
-    trig = _trigger({"company": "ACME", "email": "a@b", "phone": "1"})
-    with pytest.raises(SystemExit) as exc:
-        orchestrator.run(
-            triggers=[trig],
-            researchers=[agent_internal_search.run],
-            pdf_renderer=_stub_pdf,
-            csv_exporter=_stub_csv,
-            hubspot_upsert=lambda d: None,
-            hubspot_attach=lambda p, c: None,
-            hubspot_check_existing=lambda cid: None,
-        )
-    assert exc.value.code == 0
-    assert send_calls and send_calls[0]["to"] == "a@b"
+    trig = _trigger({"company": "ACME", "email": "a@condata.io", "phone": "1"})
+    orchestrator.run(
+        triggers=[trig],
+        researchers=[agent_internal_search.run],
+        pdf_renderer=_stub_pdf,
+        csv_exporter=_stub_csv,
+        hubspot_upsert=lambda d: None,
+        hubspot_attach=lambda p, c: None,
+        hubspot_check_existing=lambda cid: None,
+    )
+    assert send_calls and send_calls[0]["to"] == "a@condata.io"
     assert any(r.get("status") == "pending" for r in logs)
     files = list(Path("logs/workflows").glob("*.jsonl"))
     content = "".join(f.read_text() for f in files)
@@ -132,7 +130,7 @@ def test_email_reply_resumes(monkeypatch):
         "fetch_replies",
         lambda: [{"creator": "a@b", "task_id": "1", "fields": {"domain": "acme.com"}}],
     )
-    trig = _trigger({"company": "ACME", "email": "a@b", "phone": "1"})
+    trig = _trigger({"company": "ACME", "email": "a@condata.io", "phone": "1"})
     orchestrator.run(
         triggers=[trig],
         researchers=[agent_internal_search.run],
@@ -157,17 +155,16 @@ def test_irrelevant_email_ignored(monkeypatch):
         "fetch_replies",
         lambda: [{"creator": "a@b", "task_id": "999", "fields": {"domain": "x.com"}}],
     )
-    trig = _trigger({"company": "ACME", "email": "a@b", "phone": "1"})
-    with pytest.raises(SystemExit):
-        orchestrator.run(
-            triggers=[trig],
-            researchers=[agent_internal_search.run],
-            pdf_renderer=_stub_pdf,
-            csv_exporter=_stub_csv,
-            hubspot_upsert=lambda d: None,
-            hubspot_attach=lambda p, c: None,
-            hubspot_check_existing=lambda cid: None,
-        )
+    trig = _trigger({"company": "ACME", "email": "a@condata.io", "phone": "1"})
+    orchestrator.run(
+        triggers=[trig],
+        researchers=[agent_internal_search.run],
+        pdf_renderer=_stub_pdf,
+        csv_exporter=_stub_csv,
+        hubspot_upsert=lambda d: None,
+        hubspot_attach=lambda p, c: None,
+        hubspot_check_existing=lambda cid: None,
+    )
     content = "".join(f.read_text() for f in Path("logs/workflows").glob("*.jsonl"))
     assert '"status": "pending"' in content
 

--- a/tests/unit/test_email_attachments.py
+++ b/tests/unit/test_email_attachments.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from integrations import email_sender
+
+
+def test_small_attachment_sent(monkeypatch, tmp_path):
+    file = tmp_path / 'report.pdf'
+    file.write_bytes(b'x' * 1024)  # 1KB
+
+    called = {}
+
+    def fake_deliver(to, subject, body, attachments=None):
+        called['attachments'] = attachments
+        called['body'] = body
+
+    monkeypatch.setenv('SMTP_HOST', 'localhost')
+    monkeypatch.setenv('SMTP_USER', 'u')
+    monkeypatch.setenv('SMTP_PASS', 'p')
+    monkeypatch.setattr(email_sender, '_deliver', fake_deliver)
+
+    email_sender.send_email('a@b', 'sub', 'body', attachments=[str(file)])
+    assert called['attachments'] == [str(file)]
+
+
+def test_large_attachment_skipped(monkeypatch, tmp_path):
+    file = tmp_path / 'big.pdf'
+    file.write_bytes(b'x' * (6 * 1024 * 1024))
+
+    called = {}
+
+    def fake_deliver(to, subject, body, attachments=None):
+        called['attachments'] = attachments
+        called['body'] = body
+
+    logs = []
+    monkeypatch.setattr(email_sender, 'log_step', lambda *a, **k: logs.append((a, k)))
+    monkeypatch.setenv('SMTP_HOST', 'localhost')
+    monkeypatch.setenv('SMTP_USER', 'u')
+    monkeypatch.setenv('SMTP_PASS', 'p')
+    monkeypatch.setattr(email_sender, '_deliver', fake_deliver)
+
+    email_sender.send_email('a@b', 'sub', 'body', attachments=[str(file)])
+    assert called['attachments'] == []
+    assert str(file) in called['body']
+    assert any('attachment_skipped_too_large' in a for a, _ in logs)

--- a/tests/unit/test_email_sender_reminder.py
+++ b/tests/unit/test_email_sender_reminder.py
@@ -20,8 +20,8 @@ def test_send_reminder_formats_subject_and_body(monkeypatch):
     end = dt.datetime(2024, 5, 17, 10, 0)
 
     email_sender.send_reminder(
-        to='user@example.com',
-        creator_email='user@example.com',
+        to='user@condata.io',
+        creator_email='user@condata.io',
         creator_name='Alice',
         event_id='evt123',
         event_title='Demo',


### PR DESCRIPTION
## Summary
- support attachments and retry logic in low-level mailer
- add size checks, domain filter and exponential retries in email sender
- skip triggers with missing fields instead of aborting orchestrator
- clean CI workflow branch syntax

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b02f795a14832b96f61fba22b60d8c