### PR TITLE
feat: enhance auto-issue handling and severity logging

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -103,7 +103,7 @@ def gather_triggers(
         for c in fetch_contacts_fn() or []:
             triggers.append(_as_trigger_from_contact(c))
     except Exception as e:
-        log_event({"level": "error", "where": "gather_triggers", "error": str(e)})
+        log_event({"severity": "critical", "where": "gather_triggers", "error": str(e)})
         raise
     return triggers
 
@@ -252,7 +252,7 @@ def run(
                 {"event_id": first_id, "error": str(e)},
                 severity="critical",
             )
-            log_event({"status": "report_upload_failed"})
+            log_event({"status": "report_upload_failed", "severity": "critical"})
             log_step(
                 "orchestrator",
                 "report_upload_failed",
@@ -271,7 +271,7 @@ def run(
             )
             log_event({"status": "report_sent"})
         except Exception as e:
-            log_event({"status": "report_not_sent"})
+            log_event({"status": "report_not_sent", "severity": "critical"})
             log_step(
                 "orchestrator",
                 "report_not_sent",
@@ -279,7 +279,7 @@ def run(
                 severity="critical",
             )
     else:
-        log_event({"status": "report_not_sent"})
+        log_event({"status": "report_not_sent", "severity": "warning"})
         log_step(
             "orchestrator",
             "report_not_sent",

--- a/logging/errors.py
+++ b/logging/errors.py
@@ -8,7 +8,7 @@ created on GitHub (if the necessary configuration is available).
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Iterable
 import os
 
 import requests
@@ -30,11 +30,24 @@ class HardFailError(A2AError):
     all exceptions from the GitHub API are swallowed.
     """
 
-    def __init__(self, message: str, *, title: Optional[str] = None, body: str = ""):
+    def __init__(
+        self,
+        message: str,
+        *,
+        title: Optional[str] = None,
+        body: str = "",
+        labels: Optional[Iterable[str]] = None,
+        run_url: Optional[str] = None,
+    ):
         super().__init__(message)
         self.issue_url = None
         try:
-            self.issue_url = create_github_issue(title or message, body)
+            self.issue_url = create_github_issue(
+                title or message,
+                body,
+                labels=labels,
+                run_url=run_url,
+            )
         except Exception:
             # We deliberately ignore errors here – the original exception is more
             # important than the failure to file an issue.
@@ -47,6 +60,8 @@ def create_github_issue(
     *,
     repo: Optional[str] = None,
     token: Optional[str] = None,
+    labels: Optional[Iterable[str]] = None,
+    run_url: Optional[str] = None,
 ) -> Optional[str]:
     """Create a GitHub issue and return its URL.
 
@@ -62,6 +77,10 @@ def create_github_issue(
     token:
         Personal access token or GitHub App token.  If omitted the function reads
         ``GITHUB_TOKEN`` from the environment.
+    labels:
+        Optional iterable of labels to apply to the issue when created.
+    run_url:
+        URL for the workflow run – appended to the body or comment verbatim.
 
     The function returns the URL of the created issue or ``None`` if the issue
     could not be created (e.g. missing configuration).
@@ -72,14 +91,44 @@ def create_github_issue(
     if not repo or not token:
         return None
 
-    url = f"https://api.github.com/repos/{repo}/issues"
+    base = f"https://api.github.com/repos/{repo}"
+    issues_url = f"{base}/issues"
     headers = {
         "Authorization": f"token {token}",
         "Accept": "application/vnd.github+json",
     }
-    payload = {"title": title, "body": body}
+    session = requests.Session()
 
-    response = requests.post(url, headers=headers, json=payload, timeout=10)
+    # Check for an existing open issue with the same title to avoid duplicates.
+    resp = session.get(
+        issues_url,
+        headers=headers,
+        params={"state": "open", "per_page": 100},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    for issue in resp.json() or []:
+        if issue.get("title") == title:
+            comment_body = body
+            if run_url:
+                comment_body = f"{comment_body}\n\nRun URL: {run_url}" if comment_body else f"Run URL: {run_url}"
+            session.post(
+                issue.get("comments_url"),
+                headers=headers,
+                json={"body": comment_body},
+                timeout=10,
+            )
+            return issue.get("html_url")
+
+    payload = {"title": title}
+    if body:
+        payload["body"] = body
+    if run_url:
+        payload["body"] = f"{payload.get('body', '')}\n\nRun URL: {run_url}".lstrip()
+    if labels:
+        payload["labels"] = list(labels)
+
+    response = session.post(issues_url, headers=headers, json=payload, timeout=10)
     response.raise_for_status()
     return response.json().get("html_url")
 

--- a/logging/logger.py
+++ b/logging/logger.py
@@ -84,6 +84,32 @@ def get_logger(
     return logger
 
 
+SEVERITY_LEVELS = {
+    "critical": _py_logging.CRITICAL,
+    "warning": _py_logging.WARNING,
+    "info": _py_logging.INFO,
+}
+
+
+def log_with_severity(logger: _py_logging.Logger, severity: str, message: str, **kwargs: Any) -> None:
+    """Log ``message`` with a textual severity.
+
+    Parameters
+    ----------
+    logger:
+        Logger obtained via :func:`get_logger`.
+    severity:
+        One of ``"critical"``, ``"warning"`` or ``"info"`` (case-insensitive).
+    message:
+        Text to log.
+    kwargs:
+        Additional keyword arguments passed to :func:`logging.Logger.log`.
+    """
+
+    level = SEVERITY_LEVELS.get(severity.lower(), _py_logging.INFO)
+    logger.log(level, message, **kwargs)
+
+
 class _ContextFilter(_py_logging.Filter):
     """Attach ``run_id`` and ``stage`` to log records."""
 
@@ -98,5 +124,5 @@ class _ContextFilter(_py_logging.Filter):
         return True
 
 
-__all__ = ["get_logger"]
+__all__ = ["get_logger", "log_with_severity", "SEVERITY_LEVELS"]
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -14,23 +14,117 @@ spec.loader.exec_module(errors)
 def test_hard_fail_creates_github_issue(monkeypatch):
     called = {}
 
-    def fake_post(url, headers, json, timeout):  # noqa: D401 - simple stub
-        called["url"] = url
-        class Response:
-            def raise_for_status(self):
-                pass
+    class FakeSession:
+        def get(self, url, headers, params, timeout):
+            class Response:
+                def raise_for_status(self):
+                    pass
 
-            def json(self):
-                return {"html_url": "https://github.com/example/repo/issues/1"}
+                def json(self):
+                    return []
 
-        return Response()
+            return Response()
+
+        def post(self, url, headers, json, timeout):  # noqa: D401 - simple stub
+            called["url"] = url
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"html_url": "https://github.com/example/repo/issues/1"}
+
+            return Response()
 
     monkeypatch.setenv("GITHUB_REPOSITORY", "example/repo")
     monkeypatch.setenv("GITHUB_TOKEN", "secret")
-    monkeypatch.setattr(errors.requests, "post", fake_post)
+    monkeypatch.setattr(errors.requests, "Session", lambda: FakeSession())
 
     err = errors.HardFailError("Boom")
 
     assert called["url"] == "https://api.github.com/repos/example/repo/issues"
     assert err.issue_url == "https://github.com/example/repo/issues/1"
+
+
+def test_issue_deduplicates_and_comments(monkeypatch):
+    calls = {"get": 0, "post": []}
+
+    class FakeSession:
+        def get(self, url, headers, params, timeout):
+            calls["get"] += 1
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return [
+                        {
+                            "title": "Boom",
+                            "html_url": "https://github.com/example/repo/issues/2",
+                            "comments_url": "https://api.github.com/repos/example/repo/issues/2/comments",
+                        }
+                    ]
+
+            return Response()
+
+        def post(self, url, headers, json, timeout):  # noqa: D401 - simple stub
+            calls["post"].append((url, json))
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"html_url": "https://github.com/example/repo/issues/2"}
+
+            return Response()
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "example/repo")
+    monkeypatch.setenv("GITHUB_TOKEN", "secret")
+    monkeypatch.setattr(errors.requests, "Session", lambda: FakeSession())
+
+    url = errors.create_github_issue("Boom", "desc", run_url="http://run")
+    assert url == "https://github.com/example/repo/issues/2"
+    assert calls["get"] == 1
+    assert calls["post"][0][0] == "https://api.github.com/repos/example/repo/issues/2/comments"
+    assert "Run URL: http://run" in calls["post"][0][1]["body"]
+
+
+def test_issue_labels_applied(monkeypatch):
+    posts = {}
+
+    class FakeSession:
+        def get(self, url, headers, params, timeout):
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return []
+
+            return Response()
+
+        def post(self, url, headers, json, timeout):
+            posts["payload"] = json
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"html_url": "https://github.com/example/repo/issues/3"}
+
+            return Response()
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "example/repo")
+    monkeypatch.setenv("GITHUB_TOKEN", "secret")
+    monkeypatch.setattr(errors.requests, "Session", lambda: FakeSession())
+
+    url = errors.create_github_issue(
+        "Boom",
+        "desc",
+        labels=["calendar"],
+        run_url="http://run",
+    )
+    assert url == "https://github.com/example/repo/issues/3"
+    assert posts["payload"]["labels"] == ["calendar"]
+    assert posts["payload"]["body"].endswith("Run URL: http://run")
 

--- a/tests/unit/test_severity.py
+++ b/tests/unit/test_severity.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core import orchestrator  # type: ignore
+
+
+def test_log_event_severity_defaults(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    orchestrator.log_event({"status": "ok"})
+    files = list(Path("logs/workflows").glob("*.jsonl"))
+    content = files[0].read_text()
+    assert '"severity": "info"' in content
+
+    orchestrator.log_event({"status": "fail", "severity": "critical"})
+    files = sorted(Path("logs/workflows").glob("*.jsonl"))
+    content = files[-1].read_text()
+    assert '"severity": "critical"' in content
+
+
+def test_upload_failure_logged_critical(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    trig = {
+        "source": "calendar",
+        "creator": "a@example.com",
+        "recipient": "a@example.com",
+        "payload": {
+            "company": "ACME",
+            "domain": "acme.com",
+            "email": "a@example.com",
+            "phone": "1",
+        },
+    }
+
+    def stub_pdf(data, path):
+        path.write_text("pdf")
+
+    def stub_csv(data, path):
+        path.write_text("csv")
+
+    monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda **k: None)
+    def fail_attach(path, cid):
+        raise Exception("boom")
+
+    orchestrator.run(
+        triggers=[trig],
+        pdf_renderer=stub_pdf,
+        csv_exporter=stub_csv,
+        hubspot_upsert=lambda d: 1,
+        hubspot_attach=fail_attach,
+    )
+
+    content = "".join(p.read_text() for p in Path("logs/workflows").glob("*.jsonl"))
+    assert '"status": "report_upload_failed"' in content
+    assert '"severity": "critical"' in content


### PR DESCRIPTION
## Summary
- deduplicate GitHub auto-issues, support labels and run URL
- add severity-aware logging utility and apply critical/warning levels in orchestrator
- test auto-issue behaviour and severity policy

## Testing
- `pytest tests/unit/test_errors.py tests/unit/test_severity.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b034a03750832b963e44ebf7dfeab9