### PR TITLE
feat: add regex fallback for field completion

### DIFF
--- a/agents/field_completion_agent.py
+++ b/agents/field_completion_agent.py
@@ -1,8 +1,9 @@
-"""Field completion agent using OpenAI to enrich missing data."""
+"""Field completion agent using OpenAI with a regex parser fallback."""
 from __future__ import annotations
 
 import json
 import os
+import re
 from typing import Any, Dict, List
 
 try:  # pragma: no cover - optional dependency
@@ -27,34 +28,61 @@ def _collect_text(trig: Dict[str, Any]) -> str:
     return "\n".join(parts)
 
 
+COMPANY_REGEX = r"\b([A-Z][A-Za-z0-9&.\-]*(?:\s+[A-Z][A-Za-z0-9&.\-]*)*\s(?:GmbH|AG|KG|SE|Ltd|Inc|LLC))\b"
+DOMAIN_REGEX = r"\b([a-z0-9\-]+\.[a-z]{2,})(/[^\s]*)?\b"
+
+
 def run(trig: Dict[str, Any]) -> Dict[str, Any]:
-    """Attempt to fill missing ``company_name`` and ``domain`` using OpenAI."""
+    """Attempt to fill missing ``company_name`` and ``domain``.
+
+    The agent first tries to use the OpenAI API. If that fails or yields no
+    data, a lightweight regex-based parser is applied to the same text.
+    """
     text = _collect_text(trig)
-    if not text or openai is None or not os.getenv("OPENAI_API_KEY"):
+    if not text:
         return {}
-    prompt = (
-        "Extract the company name and web domain from the following text. "
-        "Respond with a JSON object containing keys 'company_name' and 'domain'."
-    )
-    try:  # pragma: no cover - network call
-        resp = openai.ChatCompletion.create(
-            model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
-            messages=[
-                {"role": "system", "content": prompt},
-                {"role": "user", "content": text},
-            ],
+
+    ai_data: Dict[str, Any] = {}
+    if openai is not None and os.getenv("OPENAI_API_KEY"):
+        prompt = (
+            "Extract the company name and web domain from the following text. "
+            "Respond with a JSON object containing keys 'company_name' and 'domain'."
         )
-        content = resp["choices"][0]["message"]["content"]
-        data = json.loads(content)
-        result: Dict[str, Any] = {}
-        if isinstance(data, dict):
-            if data.get("company_name"):
-                result["company_name"] = data["company_name"]
-            if data.get("domain"):
-                result["domain"] = data["domain"]
-        return result
-    except Exception:
-        return {}
+        try:  # pragma: no cover - network call
+            resp = openai.ChatCompletion.create(
+                model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+                messages=[
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": text},
+                ],
+            )
+            content = resp["choices"][0]["message"]["content"]
+            data = json.loads(content)
+            if isinstance(data, dict):
+                if data.get("company_name"):
+                    ai_data["company_name"] = data["company_name"]
+                if data.get("domain"):
+                    ai_data["domain"] = data["domain"]
+        except Exception:
+            ai_data = {}
+
+    result = dict(ai_data)
+
+    if not result.get("company_name"):
+        match = re.search(COMPANY_REGEX, text)
+        if match:
+            result["company_name"] = match.group(1)
+        else:
+            match = re.search(r"\b([A-Z][A-Za-z0-9&.\-]*(?:\s+[A-Z][A-Za-z0-9&.\-]*)*)", text)
+            if match:
+                result["company_name"] = match.group(1)
+
+    if not result.get("domain"):
+        match = re.search(DOMAIN_REGEX, text, re.IGNORECASE)
+        if match:
+            result["domain"] = match.group(1).lower().rstrip("/")
+
+    return result
 
 
 __all__ = ["run"]

--- a/tests/test_field_completion_agent.py
+++ b/tests/test_field_completion_agent.py
@@ -1,0 +1,62 @@
+import json
+from typing import Any, Dict
+
+import pytest
+
+from agents import field_completion_agent
+
+
+def _make_trig(summary: str) -> Dict[str, Any]:
+    return {"payload": {"summary": summary}}
+
+
+def test_openai_result_preserved(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    class FakeOpenAI:
+        class ChatCompletion:
+            @staticmethod
+            def create(*args, **kwargs):
+                return {
+                    "choices": [
+                        {"message": {"content": json.dumps({"company_name": "ACME Inc", "domain": "acme.com"})}}
+                    ]
+                }
+
+    monkeypatch.setattr(field_completion_agent, "openai", FakeOpenAI)
+
+    trig = _make_trig("Other GmbH https://other.org")
+    result = field_completion_agent.run(trig)
+    assert result == {"company_name": "ACME Inc", "domain": "acme.com"}
+
+
+def test_parser_fallback_on_openai_failure(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    class FakeOpenAI:
+        class ChatCompletion:
+            @staticmethod
+            def create(*args, **kwargs):
+                raise RuntimeError("fail")
+
+    monkeypatch.setattr(field_completion_agent, "openai", FakeOpenAI)
+
+    trig = _make_trig("Meeting with MegaCorp GmbH at https://MegaCorp.com/about")
+    result = field_completion_agent.run(trig)
+    assert result == {"company_name": "MegaCorp GmbH", "domain": "megacorp.com"}
+
+
+def test_returns_empty_when_nothing_found(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    class FakeOpenAI:
+        class ChatCompletion:
+            @staticmethod
+            def create(*args, **kwargs):
+                raise RuntimeError("fail")
+
+    monkeypatch.setattr(field_completion_agent, "openai", FakeOpenAI)
+
+    trig = _make_trig("meeting with unknown person")
+    result = field_completion_agent.run(trig)
+    assert result == {}


### PR DESCRIPTION
## Summary
- enrich missing fields using regex fallback when OpenAI output is empty or unavailable
- cover field completion scenarios with parser-based tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2247ae4f0832bafff384f9f65520b