### PR TITLE
Log raw Google Calendar events for diagnostics

### DIFF
--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -217,8 +217,23 @@ def fetch_events() -> List[Dict[str, Any]]:
         log_step(
             "calendar",
             "fetched_events",
-            {"count": len(results), "ids": [r["event_id"] for r in results]},
+            {
+                "count": len(results),
+                "events": [
+                    {
+                        "id": ev.get("id"),
+                        "summary": ev.get("summary"),
+                        "description": ev.get("description"),
+                        "start": ev.get("start"),
+                        "end": ev.get("end"),
+                        "creator": (ev.get("creator") or {}).get("email"),
+                    }
+                    for ev in raw_events
+                ],
+            },
         )
+    else:
+        log_step("calendar", "fetched_events", {"count": 0})
 
     log_step(
         "calendar",


### PR DESCRIPTION
## Summary
- Log raw Google Calendar events with IDs, summaries, and more in `fetch_events`
- Test logging for multiple and empty event responses to ensure traceability

## Testing
- `pytest tests/test_calendar_fetch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b227f1c680832b9ed36bd2db3bdc31