### PR TITLE
Include past 24h in calendar fetch window

### DIFF
--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -172,8 +172,8 @@ def fetch_events() -> List[Dict[str, Any]]:
 
     service = _service()
     now = _utc_now()
-    minutes_back = int(os.getenv("CALENDAR_MINUTES_BACK", str(7 * 24 * 60)))
-    minutes_fwd = int(os.getenv("CALENDAR_MINUTES_FWD", str(60 * 24 * 60)))
+    minutes_back = int(os.getenv("CALENDAR_MINUTES_BACK", str(24 * 60)))
+    minutes_fwd = int(os.getenv("CALENDAR_MINUTES_FWD", str(7 * 24 * 60)))
     time_min = (now - dt.timedelta(minutes=minutes_back)).isoformat().replace("+00:00", "Z")
     time_max = (now + dt.timedelta(minutes=minutes_fwd)).isoformat().replace("+00:00", "Z")
 
@@ -213,27 +213,16 @@ def fetch_events() -> List[Dict[str, Any]]:
             }
         )
 
-    if results:
-        log_step(
-            "calendar",
-            "fetched_events",
-            {
-                "count": len(results),
-                "events": [
-                    {
-                        "id": ev.get("id"),
-                        "summary": ev.get("summary"),
-                        "description": ev.get("description"),
-                        "start": ev.get("start"),
-                        "end": ev.get("end"),
-                        "creator": (ev.get("creator") or {}).get("email"),
-                    }
-                    for ev in raw_events
-                ],
-            },
-        )
-    else:
-        log_step("calendar", "fetched_events", {"count": 0})
+    log_step(
+        "calendar",
+        "fetched_events",
+        {
+            "count": len(results),
+            "time_min": time_min,
+            "time_max": time_max,
+            "ids": [r.get("event_id") for r in results],
+        },
+    )
 
     log_step(
         "calendar",

--- a/tests/test_calendar_fetch.py
+++ b/tests/test_calendar_fetch.py
@@ -49,8 +49,8 @@ def test_default_window(monkeypatch, stub_time, tmp_path):
     monkeypatch.chdir(tmp_path)
     call_rec = _setup_service(monkeypatch, [])
     google_calendar.fetch_events()
-    assert call_rec["timeMin"] == "2023-12-25T00:00:00Z"
-    assert call_rec["timeMax"] == "2024-03-01T00:00:00Z"
+    assert call_rec["timeMin"] == "2023-12-31T00:00:00Z"
+    assert call_rec["timeMax"] == "2024-01-08T00:00:00Z"
 
 
 def test_env_override(monkeypatch, stub_time, tmp_path):
@@ -118,16 +118,9 @@ def test_fetch_events_includes_creator_and_logs(monkeypatch, stub_time, tmp_path
     assert fetched_logs
     assert fetched_logs[0]["payload"] == {
         "count": 1,
-        "events": [
-            {
-                "id": "1",
-                "summary": "Meet",
-                "description": "desc",
-                "start": {"dateTime": "2024-01-01T10:00:00+00:00"},
-                "end": {"dateTime": "2024-01-01T11:00:00+00:00"},
-                "creator": "alice@example.com",
-            }
-        ],
+        "time_min": "2023-12-31T00:00:00Z",
+        "time_max": "2024-01-08T00:00:00Z",
+        "ids": ["1"],
     }
 
 
@@ -159,8 +152,9 @@ def test_fetch_events_logs_two_events(monkeypatch, stub_time, tmp_path):
     assert fetched_logs
     payload = fetched_logs[0]["payload"]
     assert payload["count"] == 2
-    assert [e["id"] for e in payload["events"]] == ["1", "2"]
-    assert [e["summary"] for e in payload["events"]] == ["A", "B"]
+    assert payload["time_min"] == "2023-12-31T00:00:00Z"
+    assert payload["time_max"] == "2024-01-08T00:00:00Z"
+    assert payload["ids"] == ["1", "2"]
 
 
 def test_fetch_events_logs_no_events(monkeypatch, stub_time, tmp_path):
@@ -175,7 +169,12 @@ def test_fetch_events_logs_no_events(monkeypatch, stub_time, tmp_path):
     google_calendar.fetch_events()
     fetched_logs = [l for l in logs if l["status"] == "fetched_events"]
     assert fetched_logs
-    assert fetched_logs[0]["payload"] == {"count": 0}
+    assert fetched_logs[0]["payload"] == {
+        "count": 0,
+        "time_min": "2023-12-31T00:00:00Z",
+        "time_max": "2024-01-08T00:00:00Z",
+        "ids": [],
+    }
 
 
 def test_orchestrator_no_triggers(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- include events from the previous 24 hours and next 7 days in Google Calendar fetch
- log fetched time window and event ids for debugging
- adjust unit tests for updated window and logging format

## Testing
- `pytest tests/test_calendar_fetch.py`

------
https://chatgpt.com/codex/tasks/task_e_68b22ad92574832baa4b6cd5ca1729b5