### PR TITLE
Guard orchestrator against demo data and add CI self-test

### DIFF
--- a/core/demo_mode.py
+++ b/core/demo_mode.py
@@ -1,0 +1,29 @@
+"""Synthetic demo events for demo mode only."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+
+def demo_events() -> List[Dict[str, Any]]:
+    """Return synthetic events used solely for demonstration.
+
+    The module should only be imported when ``DEMO_MODE`` or ``A2A_DEMO`` is
+    enabled.  It is safe to call ``demo_events`` regardless of the environment;
+    it will return an empty list if demo mode is disabled.
+    """
+
+    if os.getenv("DEMO_MODE") != "1" and os.getenv("A2A_DEMO") != "1":
+        return []
+
+    return [
+        {
+            "event_id": "e1",
+            "summary": "Demo research event",
+            "description": "",
+            "start": None,
+            "end": None,
+            "creatorEmail": "demo@example.com",
+            "creator": {"email": "demo@example.com"},
+        }
+    ]

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -145,18 +145,10 @@ def gather_triggers() -> List[Dict[str, Any]]:
         events = fetch_events()
         log_step("calendar", "fetch_return", {"count": len(events)})
         if os.getenv("A2A_DEMO") == "1" or os.getenv("DEMO_MODE") == "1":
+            from core.demo_mode import demo_events
+
             events = list(events or [])
-            events.append(
-                {
-                    "event_id": "e1",
-                    "summary": "Demo research event",
-                    "description": "",
-                    "start": None,
-                    "end": None,
-                    "creatorEmail": "demo@example.com",
-                    "creator": {"email": "demo@example.com"},
-                }
-            )
+            events.extend(demo_events())
 
         for ev in events or []:
             t = _as_trigger_from_event(ev)

--- a/tests/test_self_guard.py
+++ b/tests/test_self_guard.py
@@ -1,0 +1,78 @@
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core import orchestrator
+from core.utils import log_step
+
+
+# 1. Ensure demo events are always guarded
+
+def test_demo_events_guarded():
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    for path in repo.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        text = path.read_text()
+        if '"e1"' in text and "DEMO_MODE" not in text and "A2A_DEMO" not in text:
+            raise AssertionError(f"unguarded demo event in {path}")
+
+
+# 2. Ensure orchestrator logs fetch events
+
+def test_orchestrator_logs_fetch():
+    orch_path = pathlib.Path(__file__).resolve().parents[1] / "core" / "orchestrator.py"
+    text = orch_path.read_text()
+    assert "fetch_call" in text and "fetch_return" in text
+
+
+# 3. Ensure calendar integration logs fetched_events
+
+def test_calendar_logs_events():
+    gc_path = pathlib.Path(__file__).resolve().parents[1] / "integrations" / "google_calendar.py"
+    text = gc_path.read_text()
+    assert "fetched_events" in text
+
+
+# 4. Runtime self-test: orchestrator must log calendar fetch
+
+def test_runtime_logging(tmp_path):
+    os.environ.pop("DEMO_MODE", None)
+    os.environ.pop("A2A_DEMO", None)
+
+    log_file = pathlib.Path(__file__).resolve().parents[1] / "logs" / "workflows" / "calendar.jsonl"
+    if log_file.exists():
+        log_file.unlink()
+
+    def fake_fetch() -> list:
+        log_step(
+            "calendar",
+            "fetched_events",
+            {
+                "count": 0,
+                "time_min": "t0",
+                "time_max": "t1",
+                "ids": [],
+                "summaries": [],
+                "creator_emails": [],
+            },
+        )
+        return []
+
+    orchestrator.fetch_events = fake_fetch  # type: ignore
+    orchestrator.fetch_contacts = lambda: []  # type: ignore
+    orchestrator.reminder_service.check_and_notify = lambda _t: None  # type: ignore
+    orchestrator.email_listener.has_pending_events = lambda: False  # type: ignore
+
+    try:
+        orchestrator.run()
+    except SystemExit:
+        pass
+
+    text = log_file.read_text()
+    assert "fetch_call" in text
+    assert "fetch_return" in text
+    assert "fetched_events" in text
+    assert "e1" not in text


### PR DESCRIPTION
## Summary
- Isolate synthetic demo event generation in `core/demo_mode.py`
- Ensure orchestrator always fetches real calendar events and logs fetch calls
- Add `tests/test_self_guard.py` to enforce demo-mode guard and logging

## Testing
- `pytest tests/test_self_guard.py -q`
- `python self_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b235a50f58832b8988cabb221dfbb0