### PR TITLE
Enforce live calendar fetch and demo-mode safeguards

### DIFF
--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -56,6 +56,12 @@ def fetch_events() -> List[Normalized]:
     time_min = (now - timedelta(minutes=minutes_back)).isoformat()
     time_max = (now + timedelta(minutes=minutes_fwd)).isoformat()
 
+    log_step(
+        "calendar",
+        "fetch_call",
+        {"time_min": time_min, "time_max": time_max},
+    )
+
     results: List[Dict[str, Any]] = []
 
     try:

--- a/self_test.py
+++ b/self_test.py
@@ -21,16 +21,14 @@ def self_test() -> None:
     orch_text = orch_path.read_text()
     if len(re.findall(r"fetch_events\(", orch_text)) != 1:
         raise AssertionError("fetch_events not called exactly once in orchestrator")
-    if (
-        'log_step("calendar", "fetch_call"' not in orch_text
-        or 'log_step("calendar", "fetch_return"' not in orch_text
-    ):
-        raise AssertionError("missing fetch_call/fetch_return log steps")
+    if 'log_step("calendar", "fetch_return"' not in orch_text:
+        raise AssertionError("missing fetch_return log step")
 
     gc_path = repo / "integrations" / "google_calendar.py"
     gc_text = gc_path.read_text()
-    if "fetched_events" not in gc_text:
-        raise AssertionError("missing fetched_events logging")
+    for token in ["fetch_call", "raw_api_response", "fetched_events"]:
+        if token not in gc_text:
+            raise AssertionError(f"missing {token} logging")
     if "time_min" not in gc_text or "time_max" not in gc_text or "ids" not in gc_text:
         raise AssertionError("fetched_events logging missing fields")
     if f'"{DEMO_EVENT}"' in gc_text:

--- a/tests/self_guard_test.py
+++ b/tests/self_guard_test.py
@@ -1,0 +1,27 @@
+import json
+import os
+from pathlib import Path
+
+
+def test_calendar_fetch_logging_and_demo_mode():
+    path = Path(__file__).resolve().parents[1] / "logs" / "workflows" / "calendar.jsonl"
+    events = []
+    if path.exists():
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        events.append(json.loads(line))
+                    except Exception:
+                        continue
+
+    statuses = [e.get("status") for e in events]
+    assert "fetch_call" in statuses
+    assert "raw_api_response" in statuses
+    assert "fetched_events" in statuses
+
+    demo_flags = {os.getenv("DEMO_MODE"), os.getenv("A2A_DEMO")}
+    ids = [e.get("event_id") for e in events]
+    if "e1" in ids:
+        assert "1" in demo_flags, "Demo event found without DEMO_MODE/A2A_DEMO"

--- a/tests/self_guard_test.py
+++ b/tests/self_guard_test.py
@@ -1,20 +1,59 @@
 import json
 import os
+import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-def test_calendar_fetch_logging_and_demo_mode():
+from core import orchestrator
+from core.utils import log_step
+
+
+def test_calendar_fetch_logging_and_demo_mode(monkeypatch):
+    """Ensure calendar fetch logs exist and demo events require flags."""
+
+    os.environ.pop("DEMO_MODE", None)
+    os.environ.pop("A2A_DEMO", None)
+
     path = Path(__file__).resolve().parents[1] / "logs" / "workflows" / "calendar.jsonl"
-    events = []
     if path.exists():
-        with path.open("r", encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if line:
-                    try:
-                        events.append(json.loads(line))
-                    except Exception:
-                        continue
+        path.unlink()
+
+    sample = {"event_id": "live1", "summary": "x", "creatorEmail": "a@b.c"}
+
+    def fake_fetch():
+        log_step("calendar", "fetch_call", {})
+        log_step("calendar", "raw_api_response", {"response": {}})
+        log_step(
+            "calendar",
+            "fetched_events",
+            {
+                "count": 1,
+                "time_min": "t0",
+                "time_max": "t1",
+                "ids": [sample["event_id"]],
+                "summaries": [sample["summary"]],
+                "creator_emails": [sample["creatorEmail"]],
+            },
+        )
+        return [sample]
+
+    monkeypatch.setattr(orchestrator, "fetch_events", fake_fetch)
+    monkeypatch.setattr(orchestrator, "fetch_contacts", lambda: [])
+    monkeypatch.setattr(orchestrator.reminder_service, "check_and_notify", lambda _t: None)
+    monkeypatch.setattr(orchestrator.email_listener, "has_pending_events", lambda: False)
+
+    try:
+        orchestrator.run()
+    except SystemExit:
+        pass
+
+    events = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
 
     statuses = [e.get("status") for e in events]
     assert "fetch_call" in statuses

--- a/tests/test_self_guard.py
+++ b/tests/test_self_guard.py
@@ -26,9 +26,10 @@ def test_demo_events_guarded():
 def test_required_log_statements():
     repo = pathlib.Path(__file__).resolve().parents[1]
     orch_text = (repo / "core" / "orchestrator.py").read_text()
-    assert "fetch_call" in orch_text and "fetch_return" in orch_text
+    assert "fetch_return" in orch_text
     gc_text = (repo / "integrations" / "google_calendar.py").read_text()
-    assert "fetched_events" in gc_text
+    for token in ["fetch_call", "raw_api_response", "fetched_events"]:
+        assert token in gc_text
 
 
 # 3. Runtime validation
@@ -44,6 +45,8 @@ def test_runtime_logging(monkeypatch):
     sample_event = {"event_id": "live1", "summary": "X", "creatorEmail": "a@b.c"}
 
     def fake_fetch():
+        log_step("calendar", "fetch_call", {})
+        log_step("calendar", "raw_api_response", {"response": {}})
         log_step(
             "calendar",
             "fetched_events",
@@ -70,6 +73,7 @@ def test_runtime_logging(monkeypatch):
 
     text = log_file.read_text()
     assert "fetch_call" in text
+    assert "raw_api_response" in text
     assert "fetch_return" in text
     assert "fetched_events" in text
     assert '"e1"' not in text
@@ -80,6 +84,8 @@ def test_runtime_blocks_demo(monkeypatch):
     os.environ.pop("A2A_DEMO", None)
 
     def fake_fetch():
+        log_step("calendar", "fetch_call", {})
+        log_step("calendar", "raw_api_response", {"response": {}})
         log_step(
             "calendar",
             "fetched_events",


### PR DESCRIPTION
## Summary
- enforce calendar fetch logging and demo-mode checks in orchestrator
- log fetch start in Google Calendar integration
- add self-guard tests for log presence and demo-mode enforcement

## Testing
- `pytest tests/test_self_guard.py tests/unit/test_orchestrator_unit.py tests/self_guard_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68b34da00bf0832b9a18b59d8976fc6f