### PR TITLE
Add resilient exports with log bundles

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -15,6 +15,7 @@ from core.utils import (
     log_step,
     finalize_summary,
     get_workflow_id,
+    bundle_logs_into_exports,
 )  # noqa: F401  # required_fields/optional_fields imported for completeness
 from integrations.google_calendar import fetch_events
 from integrations.google_contacts import fetch_contacts
@@ -281,6 +282,7 @@ def run(
             }
         )
         finalize_summary()
+        bundle_logs_into_exports()
         raise SystemExit(0)
 
     if researchers is None:
@@ -332,12 +334,14 @@ def run(
             if (datetime.now(timezone.utc) - created).days < 7:
                 log_event({"event_id": first_id, "status": "report_skipped"})
                 finalize_summary()
+                bundle_logs_into_exports()
                 return consolidated
         except Exception:
             pass
 
     if duplicate_checker and duplicate_checker(consolidated, existing):
         finalize_summary()
+        bundle_logs_into_exports()
         return consolidated
 
     out_dir = Path(os.getenv("OUTPUT_DIR", "output")) / "exports"
@@ -361,6 +365,7 @@ def run(
             severity="critical",
         )
         finalize_summary()
+        bundle_logs_into_exports()
         raise
 
     if company_id is None and hubspot_upsert:
@@ -418,6 +423,7 @@ def run(
         )
 
     finalize_summary()
+    bundle_logs_into_exports()
     return consolidated
 
 

--- a/output/csv_export.py
+++ b/output/csv_export.py
@@ -1,22 +1,89 @@
 # output/csv_export.py
-"""CSV export for consolidated data."""
+"""CSV export helpers.
+
+The project historically exposed :func:`export_csv` which accepted a dictionary
+and a target :class:`~pathlib.Path` and wrote flattened key/value pairs.  For
+the new workflow exports we need a more robust variant that always writes the
+expected column headers and records a ``meta.json`` file when no rows are
+exported.  To remain backwards compatible the function now accepts both call
+styles:
+
+``export_csv(mapping, path)``
+    Legacy behaviour – write flattened key/value pairs to ``path``.
+
+``export_csv(rows, fields, reason=None)``
+    New behaviour – write rows with ``fields`` headers to
+    ``output/exports/data.csv`` and create a ``meta.json`` file when ``rows`` is
+    empty.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, List
+from datetime import datetime
 import csv
 import json
 
 
-def export_csv(data: Dict[str, Any], out_path: Path) -> None:
+def _export_kv(data: Dict[str, Any], out_path: Path) -> None:
+    """Backward compatible key/value export used in legacy tests."""
+
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    # write flattened key/value pairs
     with out_path.open("w", newline="", encoding="utf-8") as f:
-        w = csv.writer(f)
-        w.writerow(["field", "value"])
-        for k, v in data.items():
-            if k == "meta":
+        writer = csv.writer(f)
+        writer.writerow(["field", "value"])
+        for key, value in data.items():
+            if key == "meta":
                 continue
-            if isinstance(v, (dict, list)):
-                v = json.dumps(v, ensure_ascii=False)
-            w.writerow([k, str(v)])
+            if isinstance(value, (dict, list)):
+                value = json.dumps(value, ensure_ascii=False)
+            writer.writerow([key, str(value)])
+
+
+def export_csv(
+    data_or_rows: Any,
+    out_path_or_fields: Any,
+    reason: str | None = None,
+) -> None:
+    """Export consolidated data to CSV.
+
+    Parameters
+    ----------
+    data_or_rows:
+        Either a mapping of key/value pairs (legacy behaviour) or an iterable of
+        row dictionaries.
+    out_path_or_fields:
+        ``Path`` for the legacy behaviour or an iterable of field names for the
+        new style export.
+    reason:
+        Optional explanation recorded in ``meta.json`` when no rows were
+        exported.  Only used in the new behaviour.
+    """
+
+    # Legacy behaviour: ``export_csv(mapping, path)``
+    if isinstance(out_path_or_fields, (str, Path)):
+        _export_kv(data_or_rows, Path(out_path_or_fields))
+        return
+
+    # New behaviour: ``export_csv(rows, fields, reason=None)``
+    rows = list(data_or_rows or [])
+    fields: List[str] = list(out_path_or_fields or [])
+
+    outdir = Path("output/exports")
+    outdir.mkdir(parents=True, exist_ok=True)
+    csv_path = outdir / "data.csv"
+
+    with csv_path.open("w", encoding="utf-8") as f:
+        f.write(",".join(fields) + "\n")
+        for row in rows:
+            f.write(",".join(str(row.get(col, "")) for col in fields) + "\n")
+
+    if not rows:
+        meta = {
+            "exported_rows": 0,
+            "reason": reason or "no_valid_triggers_or_missing_required_fields",
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        with (outdir / "meta.json").open("w", encoding="utf-8") as f:
+            json.dump(meta, f, indent=2)

--- a/output/pdf_render.py
+++ b/output/pdf_render.py
@@ -1,28 +1,117 @@
 # output/pdf_render.py
-"""PDF rendering using WeasyPrint if available, with graceful fallback."""
+"""PDF rendering helpers.
+
+This module provides a small wrapper around WeasyPrint (when available) and a
+fallback implementation for environments without the dependency.  To remain
+compatible with legacy tests the exposed :func:`render_pdf` function accepts two
+different calling conventions:
+
+``render_pdf(mapping, path)``
+    Serialises ``mapping`` to HTML and writes the result to ``path``.  This is
+    the behaviour that existed before this change and is still used by several
+    integration tests.
+
+``render_pdf(rows, fields, meta=None)``
+    New behaviour used by export safety tests.  The report is written to
+    ``output/exports/report.pdf`` and if ``rows`` is empty a placeholder PDF is
+    generated explaining why no data is available.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Iterable, List
 import json
 
 
 def _html_from_data(data: Any) -> str:
-    return f"""<!doctype html>
-<html>
-<head><meta charset="utf-8"><title>A2A Report</title></head>
-<body>
-<h1>A2A Research Report</h1>
-<pre>{json.dumps(data, indent=2, ensure_ascii=False)}</pre>
-</body></html>"""
+    """Return a very small HTML document representing ``data``."""
+
+    return (
+        "<!doctype html>\n"
+        "<html>\n<head><meta charset=\"utf-8\"><title>A2A Report</title></head>\n"
+        "<body>\n<h1>A2A Research Report</h1>\n"
+        f"<pre>{json.dumps(data, indent=2, ensure_ascii=False)}</pre>\n"
+        "</body></html>"
+    )
 
 
-def render_pdf(data: Any, out_path: Path) -> None:
+def _write_placeholder_pdf(out_path: Path, reason: str | None) -> None:
+    """Create a tiny PDF file stating that no data was available."""
+
+    try:
+        from reportlab.lib.pagesizes import A4  # type: ignore
+        from reportlab.pdfgen import canvas  # type: ignore
+
+        c = canvas.Canvas(str(out_path), pagesize=A4)
+        c.setFont("Helvetica-Bold", 14)
+        c.drawString(100, 750, "No data to report")
+        c.setFont("Helvetica", 10)
+        c.drawString(100, 730, f"Reason: {reason or 'No valid triggers'}")
+        c.save()
+        return
+    except Exception:
+        # Dependency not available – fall back to a plain text file with .pdf
+        # extension.  While not a valid PDF it still clearly communicates the
+        # issue and keeps tests independent from external libraries.
+        out_path.write_text(
+            f"No data to report. Reason: {reason or 'No valid triggers'}",
+            encoding="utf-8",
+        )
+
+
+def render_pdf(
+    data_or_rows: Any,
+    out_path_or_fields: Any,
+    meta: Dict[str, Any] | None = None,
+) -> None:
+    """Render a PDF report.
+
+    Parameters
+    ----------
+    data_or_rows:
+        Mapping of data (legacy mode) or iterable of row dictionaries.
+    out_path_or_fields:
+        Target path (legacy) or iterable of field names (new mode).
+    meta:
+        Optional metadata used in new mode to provide a reason for empty
+        exports.
+    """
+
+    # --- Legacy behaviour: render_pdf(data, out_path) -------------------
+    if isinstance(out_path_or_fields, (str, Path)):
+        out_path = Path(out_path_or_fields)
+        html = _html_from_data(data_or_rows)
+        try:
+            from weasyprint import HTML  # type: ignore
+
+            HTML(string=html).write_pdf(str(out_path))
+        except Exception:
+            out_path.write_text(html, encoding="utf-8")
+        return
+
+    # --- New behaviour: render_pdf(rows, fields, meta) -------------------
+    rows: List[Dict[str, Any]] = list(data_or_rows or [])
+    fields: List[str] = list(out_path_or_fields or [])  # retained for future use
+
+    out_dir = Path("output/exports")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "report.pdf"
+
+    if not rows:
+        reason = (meta or {}).get("reason") if meta else None
+        _write_placeholder_pdf(out_path, reason)
+        return
+
+    data = {"rows": rows, "fields": fields, "meta": meta or {}}
     html = _html_from_data(data)
     try:
         from weasyprint import HTML  # type: ignore
 
         HTML(string=html).write_pdf(str(out_path))
     except Exception:
-        # Fallback: write HTML alongside with .pdf extension for environments without WeasyPrint
         out_path.write_text(html, encoding="utf-8")
+
+
+__all__ = ["render_pdf"]
+

--- a/tests/test_exports_safety.py
+++ b/tests/test_exports_safety.py
@@ -1,0 +1,27 @@
+import os
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from output import csv_export, pdf_render
+
+
+def test_csv_and_meta_on_empty(tmp_path):
+    rows = []
+    fields = ["company_name", "domain", "email", "phone"]
+    os.chdir(tmp_path)
+    csv_export.export_csv(rows, fields, reason="no_triggers")
+
+    assert (tmp_path / "output/exports/data.csv").exists()
+    meta = json.load(open(tmp_path / "output/exports/meta.json"))
+    assert meta["reason"] == "no_triggers"
+
+
+def test_pdf_placeholder_on_empty(tmp_path):
+    rows = []
+    os.chdir(tmp_path)
+    pdf_render.render_pdf(rows, ["company_name"], {"reason": "no_triggers"})
+    assert (tmp_path / "output/exports/report.pdf").exists()
+


### PR DESCRIPTION
## Summary
- ensure CSV export writes schema headers and meta file when empty
- render placeholder PDF for empty datasets and keep legacy support
- bundle workflow logs with exports for easier debugging

## Testing
- `pytest tests/test_exports_safety.py -q`
- `pytest tests/test_orchestrator.py::test_run_exits_when_no_triggers -q`
- `pytest tests/integration/test_workflow_outputs.py::test_orchestrator_generates_outputs_and_calls_hubspot -q`
- ⚠️ `pytest -q` (hangs after initial tests)

------
https://chatgpt.com/codex/tasks/task_e_68b4033c4fbc832bb132203d9894e4cc