### PR TITLE
Add production Docker image and compose volumes

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -1,5 +1,27 @@
-# Placeholder Dockerfile
 FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_NO_CACHE_DIR=off \
+    POETRY_VIRTUALENVS_CREATE=false
+
+# System deps for WeasyPrint (HTML → PDF)
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf2.0-0 \
+    libffi-dev libjpeg62-turbo-dev libxml2 libxslt1.1 shared-mime-info fonts-dejavu-core \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
+COPY requirements.txt /app/
+RUN python -m pip install --upgrade pip && pip install -r requirements.txt
+
+# Non-root user & writable dirs
+RUN useradd -m -u 1000 appuser
+RUN mkdir -p /app/output /app/logs /app/data
+RUN chown -R appuser:appuser /app
+USER appuser
+
 COPY . /app
-CMD ["python", "core/orchestrator.py"]
+
+VOLUME ["/app/output", "/app/logs", "/app/data"]
+ENTRYPOINT ["python", "-m", "core.orchestrator"]

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -2,4 +2,13 @@ version: '3'
 services:
   app:
     build: .
-    command: python core/orchestrator.py
+    environment:
+      - OUTPUT_DIR=/app/output
+      - TASKS_DB_URL=sqlite:///app/data/tasks.db
+    env_file:
+      - .env
+    volumes:
+      - ./output:/app/output
+      - ./logs:/app/logs
+      - ./data:/app/data
+    command: python -m core.orchestrator


### PR DESCRIPTION
## Summary
- replace placeholder Dockerfile with production-ready image including WeasyPrint system deps, non-root user, and volume mounts
- expand docker-compose configuration with environment variables, .env support, and bind-mounted output/log/data volumes

## Testing
- `sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends build-essential libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf2.0-0 libffi-dev libjpeg62-turbo-dev libxml2 libxslt1.1 shared-mime-info fonts-dejavu-core` *(fails: 403 Forbidden)*
- `pip install -r requirements.txt` *(fails: No matching distribution found for jinja2>=3.1)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b42d1a5eb0832bbcc1d1526948b12a