### PR TITLE
Unify workflow logging by run

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -56,8 +56,8 @@ def log_event(record: Dict[str, Any]) -> None:
     structure remains consistent across services.
     """
 
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
-    path = Path("logs") / "workflows" / f"{ts}_workflow.jsonl"
+    wf = get_workflow_id()
+    path = Path("logs") / "workflows" / f"{wf}.jsonl"
 
     base: Dict[str, Any] = {
         "event_id": record.get("event_id"),
@@ -88,7 +88,7 @@ def _event_id_exists(event_id: str) -> bool:
     base = Path("logs") / "workflows"
     if not base.exists():
         return False
-    for path in base.glob("*_workflow.jsonl"):
+    for path in base.glob("*.jsonl"):
         try:
             with path.open("r", encoding="utf-8") as fh:
                 for line in fh:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -40,7 +40,7 @@ def test_run_exits_when_no_triggers(monkeypatch, tmp_path):
     assert called == {"pdf": 0, "csv": 0}
 
     log_dir = Path("logs/workflows")
-    files = list(log_dir.glob("*_workflow.jsonl"))
+    files = list(log_dir.glob("*.jsonl"))
     assert files, "log file not written"
     content = files[0].read_text()
     assert '"status": "no_triggers"' in content


### PR DESCRIPTION
## Summary
- Log `log_event` entries to a per-workflow JSONL file using the current workflow id
- Scan all workflow log files when checking for duplicate events
- Align tests with new workflow log naming convention

## Testing
- `pytest tests/test_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42e78b4c4832ba91b29b1b429a9ed