### PR TITLE
feat: render PDFs using template with fallback

### DIFF
--- a/output/pdf_render.py
+++ b/output/pdf_render.py
@@ -50,7 +50,7 @@ def _html_from_data(data: Dict[str, Any]) -> str:
     fields = data.get("fields") or []
     meta = data.get("meta") or {}
     items = "".join(
-        f"<tr>{''.join(f'<td>{(r.get(f) or '')}</td>' for f in fields)}</tr>"
+        "<tr>" + "".join(f"<td>{r.get(f, '')}</td>" for f in fields) + "</tr>"
         for r in rows
     )
     head = "".join(f"<th>{f}</th>" for f in fields)
@@ -60,7 +60,9 @@ def _html_from_data(data: Dict[str, Any]) -> str:
         f"{head}"
         "</tr></thead><tbody>"
         f"{items}"
-        "</tbody></table><pre>{meta}</pre></body></html>"
+        "</tbody></table>"
+        f"<pre>{meta}</pre>"
+        "</body></html>"
     )
 
 

--- a/output/templates/pdf/report.html.j2
+++ b/output/templates/pdf/report.html.j2
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Company Dossier</title>
+    <style>
+      body { font-family: DejaVu Sans, Arial, sans-serif; margin: 24px; }
+      h1 { margin: 0 0 12px 0; }
+      table { border-collapse: collapse; width: 100%; }
+      th, td { border: 1px solid #ddd; padding: 6px 8px; }
+      th { text-align: left; }
+      small { color: #666; }
+    </style>
+  </head>
+  <body>
+    <h1>Company Dossier</h1>
+    {% if meta and meta.reason %}<p><small>Note: {{ meta.reason }}</small></p>{% endif %}
+    <table>
+      <thead>
+        <tr>{% for f in fields %}<th>{{ f }}</th>{% endfor %}</tr>
+      </thead>
+      <tbody>
+        {% for r in rows %}
+        <tr>{% for f in fields %}<td>{{ r.get(f, "") }}</td>{% endfor %}</tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- Render PDFs via Jinja2 HTML template when available with graceful fallback
- Add styled `report.html.j2` template for consistent PDF output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b430fc1ca4832b927ec7032649ab75