### PR TITLE
fix: refine domain pattern in company schema

### DIFF
--- a/schemas/company.core.schema.json
+++ b/schemas/company.core.schema.json
@@ -9,8 +9,8 @@
     },
     "domain": {
       "type": "string",
-      "format": "uri",
-      "description": "Die Web‑Domain des Unternehmens."
+      "pattern": "^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+      "description": "Hostname ohne Protokoll, z. B. 'example.com'."
     },
     "industry_group": {
       "type": "string",


### PR DESCRIPTION
## Summary
- validate company domain using hostname pattern instead of URI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b434172df4832b9a736cbec3903c3d