### PR TITLE
feat: allow configurable reminder domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,13 @@ CRM.
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `EMAIL_SMTP_HOST` | SMTP server hostname | – |
-| `MAIL_SMTP_PORT` | SMTP server port | `587` |
-| `EMAIL_SMTP_USER` | SMTP username | – |
-| `EMAIL_SMTP_PASS` | SMTP password | – |
-| `MAIL_FROM` | Sender e‑mail address | `EMAIL_SMTP_USER` |
-| `MAIL_SMTP_SECURE` | Use SSL for SMTP (`true`/`false`) | `true` |
+| `SMTP_HOST` | SMTP server hostname | – |
+| `SMTP_PORT` | SMTP server port | `587` |
+| `SMTP_USER` | SMTP username | – |
+| `SMTP_PASS` | SMTP password | – |
+| `MAIL_FROM` | Sender e‑mail address | `SMTP_USER` |
+| `SMTP_SECURE` | SMTP security mode (`ssl`/`starttls`) | `ssl` |
+| `ALLOWLIST_EMAIL_DOMAIN` | Allow reminder emails only to addresses in this domain | – |
 | `MAIL_TO` | Recipient e‑mail for reports | – |
 | `TRIGGER_WORDS_FILE` | Path to trigger words list | `config/trigger_words.txt` |
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID | – |

--- a/integrations/email_sender.py
+++ b/integrations/email_sender.py
@@ -237,8 +237,9 @@ Thanks a lot for your support!
 "Your Internal Research Agent"
 """
 
-    # Allow reminders only for company domains
-    if not to.lower().endswith("@condata.io"):
+    # Allow reminders only for a configured company domain (optional)
+    allow = os.getenv("ALLOWLIST_EMAIL_DOMAIN")
+    if allow and not to.lower().endswith(f"@{allow.lower()}"):
         log_step(
             "mailer",
             "reminder_skipped_invalid_domain",

--- a/ops/CONFIG.md
+++ b/ops/CONFIG.md
@@ -19,6 +19,7 @@ See repository README for common variables.
 - `SMTP_PASS`
 - `MAIL_FROM`
 - `SMTP_SECURE`
+- `ALLOWLIST_EMAIL_DOMAIN` (optional)
 
 ## Trigger Words
 - `TRIGGER_WORDS_FILE` (defaults to `config/trigger_words.txt`)


### PR DESCRIPTION
## Summary
- make reminder email domain allowlist configurable via `ALLOWLIST_EMAIL_DOMAIN`
- unify SMTP environment variable documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43550d244832b8f693856396ef1b5