### PR TITLE
fix: use unified workflow log naming for duplicate events

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -88,7 +88,7 @@ def _event_id_exists(event_id: str) -> bool:
     base = Path("logs") / "workflows"
     if not base.exists():
         return False
-    for path in base.glob("*.jsonl"):
+    for path in base.glob("wf-*.jsonl"):
         try:
             with path.open("r", encoding="utf-8") as fh:
                 for line in fh:


### PR DESCRIPTION
## Summary
- search only run-scoped workflow logs when checking for duplicate events

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4623bd6cc832bb5aae3087510052b