### PR TITLE
Add idle artifact generation and update CI for WeasyPrint

### DIFF
--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libcairo2 libpango-1.0-0 libpangoft2-1.0-0 \
-            libgdk-pixbuf2.0-0 libffi-dev libxml2 libxslt1.1 \
+            libgdk-pixbuf-2.0-0 libffi-dev libxml2 libxslt1.1 \
             fonts-dejavu-core
 
       - name: Install dev dependencies
@@ -64,7 +64,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libcairo2 libpango-1.0-0 libpangoft2-1.0-0 \
-            libgdk-pixbuf2.0-0 libffi-dev libxml2 libxslt1.1 \
+            libgdk-pixbuf-2.0-0 libffi-dev libxml2 libxslt1.1 \
             fonts-dejavu-core
 
       - name: Install dependencies

--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Install OS packages for WeasyPrint
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf2.0-0 libffi-dev libxml2 libxslt1.1 fonts-dejavu-core
+          sudo apt-get install -y \
+            libcairo2 libpango-1.0-0 libpangoft2-1.0-0 \
+            libgdk-pixbuf2.0-0 libffi-dev libxml2 libxslt1.1 \
+            fonts-dejavu-core
 
       - name: Install dev dependencies
         run: |
@@ -59,7 +62,10 @@ jobs:
       - name: Install OS packages for WeasyPrint
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf2.0-0 libffi-dev libxml2 libxslt1.1 fonts-dejavu-core
+          sudo apt-get install -y \
+            libcairo2 libpango-1.0-0 libpangoft2-1.0-0 \
+            libgdk-pixbuf2.0-0 libffi-dev libxml2 libxslt1.1 \
+            fonts-dejavu-core
 
       - name: Install dependencies
         run: |
@@ -69,54 +75,25 @@ jobs:
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
 
-      - name: Preflight env check
+      - name: Run orchestrator (LIVE)
         env:
-          GOOGLE_CLIENT_ID:      ${{ secrets.GOOGLE_CLIENT_ID || secrets.GOOGLE_CLIENT_ID_V2 || vars.GOOGLE_CLIENT_ID || vars.GOOGLE_CLIENT_ID_V2 }}
-          GOOGLE_CLIENT_SECRET:  ${{ secrets.GOOGLE_CLIENT_SECRET || secrets.GOOGLE_CLIENT_SECRET_V2 || vars.GOOGLE_CLIENT_SECRET || vars.GOOGLE_CLIENT_SECRET_V2 }}
-          GOOGLE_REFRESH_TOKEN:  ${{ secrets.GOOGLE_REFRESH_TOKEN || vars.GOOGLE_REFRESH_TOKEN }}
-          HUBSPOT_ACCESS_TOKEN:  ${{ secrets.HUBSPOT_ACCESS_TOKEN || vars.HUBSPOT_ACCESS_TOKEN }}
-          HUBSPOT_PORTAL_ID:     ${{ secrets.HUBSPOT_PORTAL_ID || vars.HUBSPOT_PORTAL_ID }}
-          SMTP_HOST:             ${{ secrets.SMTP_HOST || vars.SMTP_HOST }}
-          SMTP_PORT:             ${{ secrets.SMTP_PORT || vars.SMTP_PORT }}
-          SMTP_USER:             ${{ secrets.SMTP_USER || vars.SMTP_USER }}
-          SMTP_PASS:             ${{ secrets.SMTP_PASS || vars.SMTP_PASS }}
-          SMTP_SECURE:           ${{ secrets.SMTP_SECURE || vars.SMTP_SECURE }}
-          SMTP_FROM:             ${{ secrets.SMTP_FROM || secrets.MAIL_FROM || vars.SMTP_FROM || vars.MAIL_FROM }}
-        run: |
-          set -e
-          for v in GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_REFRESH_TOKEN HUBSPOT_ACCESS_TOKEN HUBSPOT_PORTAL_ID SMTP_HOST SMTP_PORT SMTP_USER SMTP_PASS SMTP_SECURE SMTP_FROM; do
-            if [ -z "${!v}" ]; then
-              echo "::error::Missing required env $v"
-              exit 1
-            else
-              echo "$v=✓"
-            fi
-          done
-
-      - name: Run orchestrator
-        if: ${{ always() }}
-        env:
-          PYTHONPATH:           ${{ env.PYTHONPATH }}
-          GOOGLE_CLIENT_ID:     ${{ secrets.GOOGLE_CLIENT_ID || secrets.GOOGLE_CLIENT_ID_V2 || vars.GOOGLE_CLIENT_ID || vars.GOOGLE_CLIENT_ID_V2 }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET || secrets.GOOGLE_CLIENT_SECRET_V2 || vars.GOOGLE_CLIENT_SECRET || vars.GOOGLE_CLIENT_SECRET_V2 }}
-          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN || vars.GOOGLE_REFRESH_TOKEN }}
-          HUBSPOT_ACCESS_TOKEN: ${{ secrets.HUBSPOT_ACCESS_TOKEN || vars.HUBSPOT_ACCESS_TOKEN }}
-          HUBSPOT_PORTAL_ID:    ${{ secrets.HUBSPOT_PORTAL_ID || vars.HUBSPOT_PORTAL_ID }}
-          SMTP_HOST:            ${{ secrets.SMTP_HOST || vars.SMTP_HOST }}
-          SMTP_PORT:            ${{ secrets.SMTP_PORT || vars.SMTP_PORT }}
-          SMTP_USER:            ${{ secrets.SMTP_USER || vars.SMTP_USER }}
-          SMTP_PASS:            ${{ secrets.SMTP_PASS || vars.SMTP_PASS }}
-          SMTP_SECURE:          ${{ secrets.SMTP_SECURE || vars.SMTP_SECURE }}
-          SMTP_FROM:            ${{ secrets.SMTP_FROM || secrets.MAIL_FROM || vars.SMTP_FROM || vars.MAIL_FROM }}
+          GOOGLE_CLIENT_ID:      ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET:  ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_REFRESH_TOKEN:  ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+          HUBSPOT_ACCESS_TOKEN:  ${{ secrets.HUBSPOT_ACCESS_TOKEN }}
+          HUBSPOT_PORTAL_ID:     ${{ secrets.HUBSPOT_PORTAL_ID }}
+          SMTP_HOST:             ${{ secrets.SMTP_HOST }}
+          SMTP_PORT:             ${{ secrets.SMTP_PORT }}
+          SMTP_USER:             ${{ secrets.SMTP_USER }}
+          SMTP_PASS:             ${{ secrets.SMTP_PASS }}
+          SMTP_SECURE:           ${{ secrets.SMTP_SECURE }}
+          MAIL_FROM:             ${{ secrets.MAIL_FROM }}
         run: python -m core.orchestrator
 
-      - name: Upload outputs (optional)
-        if: always()
+      - name: Upload exports
         uses: actions/upload-artifact@v4
         with:
-          name: outputs
+          name: exports
           path: |
-            output/**
+            output/exports/**
             logs/workflows/**
-            **/*.pdf
-          if-no-files-found: ignore

--- a/.github/workflows/smtp_selftest.yml
+++ b/.github/workflows/smtp_selftest.yml
@@ -19,13 +19,6 @@ on:
 jobs:
   send:
     runs-on: ubuntu-latest
-    env:
-      SMTP_HOST:   ${{ secrets.SMTP_HOST }}
-      SMTP_PORT:   ${{ secrets.SMTP_PORT }}
-      SMTP_USER:   ${{ secrets.SMTP_USER }}
-      SMTP_PASS:   ${{ secrets.SMTP_PASS }}
-      SMTP_SECURE: ${{ secrets.SMTP_SECURE }}
-      SMTP_FROM:   ${{ secrets.SMTP_FROM || secrets.MAIL_FROM }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,6 +34,13 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Send test mail
+        env:
+          SMTP_HOST:   ${{ secrets.SMTP_HOST }}
+          SMTP_PORT:   ${{ secrets.SMTP_PORT }}
+          SMTP_USER:   ${{ secrets.SMTP_USER }}
+          SMTP_PASS:   ${{ secrets.SMTP_PASS }}
+          SMTP_SECURE: ${{ secrets.SMTP_SECURE }}
+          MAIL_FROM:   ${{ secrets.MAIL_FROM }}
         run: |
           python - <<'PY'
           from integrations.email_sender import send_email

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -7,7 +7,7 @@ ENV PYTHONUNBUFFERED=1 \
 
 # System deps for WeasyPrint (HTML → PDF)
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf-xlib-2.0-0 \
+    build-essential libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf2.0-0 \
     libffi-dev libjpeg62-turbo-dev libxml2 libxslt1.1 shared-mime-info fonts-dejavu-core \
  && rm -rf /var/lib/apt/lists/*
 

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -7,7 +7,7 @@ ENV PYTHONUNBUFFERED=1 \
 
 # System deps for WeasyPrint (HTML → PDF)
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf2.0-0 \
+    build-essential libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf-2.0-0 \
     libffi-dev libjpeg62-turbo-dev libxml2 libxslt1.1 shared-mime-info fonts-dejavu-core \
  && rm -rf /var/lib/apt/lists/*
 

--- a/tests/e2e/test_idle_artifacts.py
+++ b/tests/e2e/test_idle_artifacts.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core import orchestrator
+
+
+def test_idle_artifacts_created(tmp_path, monkeypatch):
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path / "out"))
+    # Leere Trigger erzwingen
+    res = orchestrator.run(triggers=[])
+    out = Path(tmp_path / "out" / "exports")
+    assert (out / "report.pdf").exists() and (out / "report.pdf").stat().st_size > 1000
+    assert (out / "data.csv").exists() and (out / "data.csv").read_text().strip() != "csv"

--- a/tests/test_calendar_fetch.py
+++ b/tests/test_calendar_fetch.py
@@ -197,9 +197,8 @@ def test_orchestrator_no_triggers(monkeypatch, tmp_path):
     monkeypatch.setattr(orchestrator, "gather_triggers", lambda *a, **k: [])
     records = []
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
-    with pytest.raises(SystemExit) as exc:
-        orchestrator.run()
-    assert exc.value.code == 0
+    res = orchestrator.run()
+    assert res == {"status": "idle"}
     assert records and records[0]["status"] == "no_triggers"
     assert (
         records[0]["message"]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -22,28 +22,18 @@ def _dummy_trigger():
 def test_run_exits_when_no_triggers(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(orchestrator, "gather_triggers", lambda *a, **k: [])
-
-    called = {"pdf": 0, "csv": 0}
-
-    def fake_pdf(data, path):
-        called["pdf"] += 1
-
-    def fake_csv(data, path):
-        called["csv"] += 1
-
     monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
-
-    with pytest.raises(SystemExit) as exc:
-        orchestrator.run(pdf_renderer=fake_pdf, csv_exporter=fake_csv)
-
-    assert exc.value.code == 0
-    assert called == {"pdf": 0, "csv": 0}
+    res = orchestrator.run()
+    assert res == {"status": "idle"}
 
     log_dir = Path("logs/workflows")
     files = list(log_dir.glob("*.jsonl"))
     assert files, "log file not written"
     content = files[0].read_text()
     assert '"status": "no_triggers"' in content
+    out_dir = Path("output/exports")
+    assert (out_dir / "report.pdf").exists()
+    assert (out_dir / "data.csv").exists()
 
 
 def test_run_processes_with_triggers(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Fix WeasyPrint system dependencies in workflows and Dockerfile
- Generate PDF and CSV artifacts when no triggers are found
- Run orchestrator with environment secrets and upload exports
- Provide environment variables for SMTP self test
- Add and update tests for idle mode behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46def27c4832bb21376da899aa41c