### PR TITLE
Force real exporters and ensure workflow completion logging

### DIFF
--- a/tests/test_calendar_fetch.py
+++ b/tests/test_calendar_fetch.py
@@ -199,8 +199,9 @@ def test_orchestrator_no_triggers(monkeypatch, tmp_path):
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
     res = orchestrator.run()
     assert res == {"status": "idle"}
-    assert records and records[0]["status"] == "no_triggers"
+    assert any(r["status"] == "no_triggers" for r in records)
+    no_trig = next(r for r in records if r["status"] == "no_triggers")
     assert (
-        records[0]["message"]
+        no_trig["message"]
         == "No calendar or contact events matched trigger words"
     )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -39,6 +39,7 @@ def test_run_exits_when_no_triggers(monkeypatch, tmp_path):
 def test_run_processes_with_triggers(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
+    monkeypatch.setenv("A2A_TEST_MODE", "1")
 
     called = {"pdf": 0, "csv": 0}
 

--- a/tests/unit/test_hubspot_api.py
+++ b/tests/unit/test_hubspot_api.py
@@ -170,6 +170,7 @@ def _run_no_upload(monkeypatch, tmp_path, upsert_return, pdf_write):
     monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "tok")
     monkeypatch.setenv("HUBSPOT_PORTAL_ID", "portal")
     monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setenv("A2A_TEST_MODE", "1")
     monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
 
     called = {"attach": 0}


### PR DESCRIPTION
## Summary
- enforce real PDF/CSV exporters in live mode, with test-mode overrides
- log workflow start/completion and protect against stub artifacts
- ensure CLI finalizes logs even on exit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b499360338832baa9524a6d10db3a4