### PR TITLE
ci: fix volume mount path

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -59,5 +59,5 @@ jobs:
       - name: "Smoke: container build & run"
         run: |
           docker build -t a2a:ci -f ops/Dockerfile .
-          docker run --rm -e USE_PUSH_TRIGGERS=1 -v $PWD/output:/app/output a2a:ci || true
+          docker run --rm -e USE_PUSH_TRIGGERS=1 -v "$PWD"/output:/app/output a2a:ci || true
           test -d output/exports


### PR DESCRIPTION
## Summary
- ensure smoke test mounts output directory correctly when running the CI Docker image

## Testing
- `python -m pytest tests/test_ci_cd_workflow_yaml.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4abe4c90c832b9ce350f6b2cb94f2