### PR TITLE
feat: allowlist for missing fields reminder

### DIFF
--- a/integrations/email_sender.py
+++ b/integrations/email_sender.py
@@ -177,6 +177,10 @@ def send_missing_fields_reminder(
         "Your colleague from the Research Team"
     )
 
+    allow = os.getenv("ALLOWLIST_EMAIL_DOMAIN")
+    if allow and not recipient_email.lower().endswith(f"@{allow.lower()}"):
+        log_step("mailer", "reminder_skipped_invalid_domain", {"to": recipient_email}, severity="warning")
+        return
     send_email(to=recipient_email, subject=subject, body=body)
 
 


### PR DESCRIPTION
## Summary
- only send missing-fields reminders to emails matching ALLOWLIST_EMAIL_DOMAIN

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ae870dd4832bb2a2b7b466827a20