### PR TITLE
Add artifact integrity E2E test

### DIFF
--- a/tests/e2e/test_artifact_integrity.py
+++ b/tests/e2e/test_artifact_integrity.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core import orchestrator
+
+
+def test_exports_are_real(tmp_path, monkeypatch):
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path/"out"))
+    monkeypatch.setenv("A2A_TEST_MODE", "0")
+    res = orchestrator.run(triggers=[])
+    pdf = Path(tmp_path/"out"/"exports"/"report.pdf")
+    csv = Path(tmp_path/"out"/"exports"/"data.csv")
+    assert pdf.exists() and pdf.stat().st_size > 1000
+    assert csv.exists() and csv.stat().st_size > 5


### PR DESCRIPTION
## Summary
- add end-to-end test ensuring generated PDF and CSV exports are non-empty

## Testing
- `pytest tests/e2e/test_artifact_integrity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b0ee4704832bab6d61fb50d1bdff