### PR TITLE
docs: document MAIL_FROM and IMAP settings

### DIFF
--- a/ops/CONFIG.md
+++ b/ops/CONFIG.md
@@ -17,9 +17,17 @@ See repository README for common variables.
 - `SMTP_PORT`
 - `SMTP_USER`
 - `SMTP_PASS`
-- `SMTP_FROM`
 - `SMTP_SECURE`
+- `SMTP_FROM` (optional)
+- `MAIL_FROM` (preferred; falls back to `SMTP_FROM`)
 - `ALLOWLIST_EMAIL_DOMAIN` (optional)
+
+## IMAP (optional)
+- `IMAP_HOST`
+- `IMAP_PORT`
+- `IMAP_USER`
+- `IMAP_PASS`
+- `IMAP_FOLDER` (default: `INBOX`)
 
 ## Trigger Words
 - `TRIGGER_WORDS_FILE` (defaults to `config/trigger_words.txt`)


### PR DESCRIPTION
## Summary
- clarify email configuration with optional MAIL_FROM and fallback to SMTP_FROM
- add optional IMAP configuration section detailing host, port, user, pass, and folder defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b6dca5f8832b8bbe4f057080a55a