### PR TITLE
Add ReportLab dependency for PDF fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ pyyaml
 pytest
 
 jinja2>=3.1
+
+reportlab>=3.6


### PR DESCRIPTION
## Summary
- ensure valid PDF fallback when WeasyPrint is unavailable by including ReportLab

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b891de1c832b8a3beebc270c45e9