### PR TITLE
Validate Google Calendar credentials before API calls

### DIFF
--- a/tests/test_calendar_fetch.py
+++ b/tests/test_calendar_fetch.py
@@ -49,6 +49,9 @@ def _setup_service(monkeypatch, items):
     svc = _StubService(items, rec)
     monkeypatch.setattr(google_calendar, "build", lambda *a, **k: svc)
     monkeypatch.setattr(google_calendar, "Credentials", lambda *a, **k: object())
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "token")
     return rec
 
 


### PR DESCRIPTION
## Summary
- Avoid attempting Google Calendar API calls when OAuth credentials are missing
- Emit clear logs for missing credential env vars and return empty result set
- Adapt calendar fetch tests to provide stubbed credentials

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4beb4ad9c832b979e9866f3eca183