### PR TITLE
Handle missing calendar events gracefully

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -204,7 +204,16 @@ def gather_triggers() -> List[Dict[str, Any]]:
                 )
                 continue
             triggers.append(trig)
-        for c in fetch_contacts() or []:
+        try:
+            contacts = fetch_contacts() or []
+        except Exception as e:
+            log_event({
+                "status": "contacts_fetch_failed",
+                "severity": "warning",
+                "error": str(e),
+            })
+            contacts = []
+        for c in contacts:
             t = _as_trigger_from_contact(c)
             if t:
                 triggers.append(t)

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -177,7 +177,8 @@ def gather_triggers() -> List[Dict[str, Any]]:
             })
 
         if not events or not any(e.get("event_id") for e in events):
-            raise SystemExit("No real calendar events detected – aborting run")
+            log_event({"status": "no_calendar_events", "severity": "warning"})
+            events = []
 
         log_step("calendar", "fetch_return", {"count": len(events)})
 

--- a/tests/unit/test_orchestrator_logging.py
+++ b/tests/unit/test_orchestrator_logging.py
@@ -27,3 +27,16 @@ def test_gather_triggers_logs_discard_reasons(tmp_path, monkeypatch):
     reasons = [r.get("reason") for r in records if r.get("status") == "event_discarded"]
     assert "no_trigger_match" in reasons
     assert "missing_fields" in reasons
+
+
+def test_gather_triggers_logs_no_calendar_events(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(orchestrator, "fetch_events", lambda: [])
+    monkeypatch.setattr(orchestrator, "fetch_contacts", lambda: [])
+    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: True)
+    records = []
+    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+
+    triggers = orchestrator.gather_triggers()
+    assert triggers == []
+    assert any(r.get("status") == "no_calendar_events" for r in records)


### PR DESCRIPTION
## Summary
- avoid stopping workflow when calendar events list is empty
- test logging of `no_calendar_events` status in gather_triggers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4bfff3994832b91b6a3392906ec56