### PR TITLE
Expand trigger detection to whole calendar event

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -131,8 +131,8 @@ def _calendar_fetch_logged(wf_id: str) -> bool:
 
 # --------- Trigger-Gathering für Kalender + Kontakte ----------
 def _as_trigger_from_event(ev: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    text = (ev.get("summary") or "") + " " + (ev.get("description") or "")
-    if not contains_trigger(text):
+    # prüft summary, description, location, attendees[].email usw.
+    if not contains_trigger(ev):
         return None
 
     return {

--- a/tests/unit/test_as_trigger_from_event.py
+++ b/tests/unit/test_as_trigger_from_event.py
@@ -27,3 +27,37 @@ def test_as_trigger_from_event_returns_payload_when_trigger_present():
         "recipient": "bob@example.com",
         "payload": ev,
     }
+
+
+def test_as_trigger_from_event_detects_trigger_in_location():
+    ev = {
+        "summary": "Regular meeting",
+        "description": "",
+        "location": "Research campus",
+        "creator": {"email": "alice@example.com"},
+        "organizer": {"email": "bob@example.com"},
+    }
+    trig = orchestrator._as_trigger_from_event(ev)
+    assert trig == {
+        "source": "calendar",
+        "creator": "alice@example.com",
+        "recipient": "bob@example.com",
+        "payload": ev,
+    }
+
+
+def test_as_trigger_from_event_detects_trigger_in_attendee():
+    ev = {
+        "summary": "Regular meeting",
+        "description": "",
+        "attendees": [{"email": "carol@meetingvorbereitung.com"}],
+        "creator": {"email": "alice@example.com"},
+        "organizer": {"email": "bob@example.com"},
+    }
+    trig = orchestrator._as_trigger_from_event(ev)
+    assert trig == {
+        "source": "calendar",
+        "creator": "alice@example.com",
+        "recipient": "bob@example.com",
+        "payload": ev,
+    }


### PR DESCRIPTION
## Summary
- broaden `_as_trigger_from_event` to run trigger detection on the entire event payload
- add tests for triggers in `location` and attendee emails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c266dcdc832b8f9cdbc101edeae1