### PR TITLE
Ensure workflow finalization always logs completion

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -498,9 +498,8 @@ def main(argv: List[str] | None = None) -> int:
     finally:
         try:
             finalize_summary(); bundle_logs_into_exports()
-        except Exception:
-            pass
-        log_event({"status": "workflow_completed"})
+        finally:
+            log_event({"status": "workflow_completed"})
     return 0
 
 


### PR DESCRIPTION
## Summary
- guarantee finalize_summary and bundling run after main run execution and log workflow_completed event

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c4aa66e0832b8af797c677ebcef5