### PR TITLE
Log calendar window when no triggers

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -302,6 +302,16 @@ def run(
 
     if not triggers:
         log_event({
+            "status": "no_triggers_diagnostics",
+            "details": {
+                "window": {
+                    "back_min": int(os.getenv("CALENDAR_MINUTES_BACK", "1440")),
+                    "fwd_min": int(os.getenv("CALENDAR_MINUTES_FWD", "10080")),
+                }
+            },
+            "severity": "info",
+        })
+        log_event({
             "status": "no_triggers",
             "message": "No calendar or contact events matched trigger words"
         })


### PR DESCRIPTION
## Summary
- log calendar window details when no triggers are produced

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4c9e34118832ba2a51f116eb33137