### PR TITLE
docs: document Google OAuth alt keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
 # === Google OAuth (People API + Calendar) ===
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# optional alternative Keynamen (wie im Screenshot)
+# werden automatisch erkannt, müssen NICHT zusätzlich gesetzt werden
+GOOGLE_CLIENT_ID_V2=
+GOOGLE_CLIENT_SECRET_V2=
 GOOGLE_REFRESH_TOKEN=
 GOOGLE_TOKEN_URI=https://oauth2.googleapis.com/token
+# optional: gesamtes Client-JSON als String
+# GOOGLE_OAUTH_JSON=
 
 # === HubSpot ===
 HUBSPOT_ACCESS_TOKEN=

--- a/ops/CONFIG.md
+++ b/ops/CONFIG.md
@@ -5,9 +5,11 @@ See repository README for common variables.
 
 ## Secrets
 - `HUBSPOT_ACCESS_TOKEN`
-- `GOOGLE_CLIENT_ID`
-- `GOOGLE_CLIENT_SECRET`
-- `GOOGLE_REFRESH_TOKEN`
+- Erforderlich: `GOOGLE_CLIENT_ID` **oder** `GOOGLE_CLIENT_ID_V2`
+  `GOOGLE_CLIENT_SECRET` **oder** `GOOGLE_CLIENT_SECRET_V2`
+  `GOOGLE_REFRESH_TOKEN`
+- Optional:    `GOOGLE_TOKEN_URI` (Default: https://oauth2.googleapis.com/token)
+  `GOOGLE_OAUTH_JSON` (alternativ gesamtes JSON)
 - `SMTP_HOST` (optional)
 - `SMTP_USER` (optional)
 - `SMTP_PASS` (optional)


### PR DESCRIPTION
## Summary
- expand env example with alternative Google OAuth variable names
- clarify required and optional Google OAuth variables in ops docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4d55a577c832bbcb26e21fbaee097