### PR TITLE
Add tests for Google OAuth env mapping

### DIFF
--- a/tests/test_google_oauth_env_mapping.py
+++ b/tests/test_google_oauth_env_mapping.py
@@ -1,0 +1,39 @@
+import os
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from integrations.google_oauth import build_user_credentials
+
+SCOPES = ["x"]
+
+def _clear(keys):
+    for k in keys:
+        os.environ.pop(k, None)
+
+def test_v2_names_work(monkeypatch):
+    _clear([
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "GOOGLE_REFRESH_TOKEN",
+        "GOOGLE_CLIENT_ID_V2",
+        "GOOGLE_CLIENT_SECRET_V2",
+    ])
+    monkeypatch.setenv("GOOGLE_CLIENT_ID_V2", "id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET_V2", "sec")
+    monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "rt")
+    assert build_user_credentials(SCOPES) is not None
+
+def test_v1_names_work(monkeypatch):
+    _clear([
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "GOOGLE_REFRESH_TOKEN",
+        "GOOGLE_CLIENT_ID_V2",
+        "GOOGLE_CLIENT_SECRET_V2",
+    ])
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "sec")
+    monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "rt")
+    assert build_user_credentials(SCOPES) is not None


### PR DESCRIPTION
## Summary
- add tests ensuring Google OAuth credential builder handles both v1 and v2 env variable names

## Testing
- `pytest tests/test_google_oauth_env_mapping.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4d93d64ac832bb7babca4a7503112