### PR TITLE
feat: unify Google OAuth and harden calendar fetching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,12 @@
 # === Google OAuth (People API + Calendar) ===
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-# optional alternative Keynamen (wie im Screenshot)
-# werden automatisch erkannt, müssen NICHT zusätzlich gesetzt werden
+# Alternative names (auto-detected; you do not need both):
 GOOGLE_CLIENT_ID_V2=
 GOOGLE_CLIENT_SECRET_V2=
 GOOGLE_REFRESH_TOKEN=
 GOOGLE_TOKEN_URI=https://oauth2.googleapis.com/token
-# optional: gesamtes Client-JSON als String
+# Optional: full client JSON as a single env var (stringified JSON):
 # GOOGLE_OAUTH_JSON=
 
 # === HubSpot ===
@@ -27,9 +26,10 @@ IMAP_USER=bot@example.com
 IMAP_PASS=
 IMAP_FOLDER=INBOX
 
-# === Calendar Window ===
-CALENDAR_MINUTES_BACK=1440
-CALENDAR_MINUTES_FWD=10080
+# === Calendar Polling Window ===
+GOOGLE_CALENDAR_IDS=primary
+CAL_LOOKAHEAD_DAYS=14
+CAL_LOOKBACK_DAYS=1
 
 # === Feature Flags ===
 USE_PUSH_TRIGGERS=0

--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -87,21 +87,22 @@ jobs:
 
       - name: Run orchestrator (LIVE)
         env:
-          GOOGLE_CLIENT_ID:      ${{ secrets.GOOGLE_CLIENT_ID || secrets.GOOGLE_CLIENT_ID_V2 || vars.GOOGLE_CLIENT_ID || vars.GOOGLE_CLIENT_ID_V2 }}
-          GOOGLE_CLIENT_SECRET:  ${{ secrets.GOOGLE_CLIENT_SECRET || secrets.GOOGLE_CLIENT_SECRET_V2 || vars.GOOGLE_CLIENT_SECRET || vars.GOOGLE_CLIENT_SECRET_V2 }}
-          GOOGLE_REFRESH_TOKEN:  ${{ secrets.GOOGLE_REFRESH_TOKEN || vars.GOOGLE_REFRESH_TOKEN }}
-          GOOGLE_TOKEN_URI:      ${{ secrets.GOOGLE_TOKEN_URI || 'https://oauth2.googleapis.com/token' }}
-          HUBSPOT_ACCESS_TOKEN:  ${{ secrets.HUBSPOT_ACCESS_TOKEN }}
-          HUBSPOT_PORTAL_ID:     ${{ secrets.HUBSPOT_PORTAL_ID }}
-          SMTP_HOST:             ${{ secrets.SMTP_HOST }}
-          SMTP_PORT:             ${{ secrets.SMTP_PORT }}
-          SMTP_USER:             ${{ secrets.SMTP_USER }}
-          SMTP_PASS:             ${{ secrets.SMTP_PASS }}
-          SMTP_SECURE:           ${{ secrets.SMTP_SECURE }}
-          MAIL_FROM:             ${{ secrets.MAIL_FROM }}
-          CALENDAR_MINUTES_BACK: "1440"   # 24h rückwärts
-          CALENDAR_MINUTES_FWD:  "10080"  # 7 Tage vorwärts
-          A2A_TEST_MODE:         "0"
+          GOOGLE_CLIENT_ID:     ${{ secrets.GOOGLE_CLIENT_ID || secrets.GOOGLE_CLIENT_ID_V2 }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET || secrets.GOOGLE_CLIENT_SECRET_V2 }}
+          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+          GOOGLE_TOKEN_URI:     ${{ secrets.GOOGLE_TOKEN_URI || 'https://oauth2.googleapis.com/token' }}
+          GOOGLE_CALENDAR_IDS:  ${{ secrets.GOOGLE_CALENDAR_IDS || 'primary' }}
+          CAL_LOOKAHEAD_DAYS:   30
+          CAL_LOOKBACK_DAYS:    2
+          HUBSPOT_ACCESS_TOKEN: ${{ secrets.HUBSPOT_ACCESS_TOKEN }}
+          HUBSPOT_PORTAL_ID:    ${{ secrets.HUBSPOT_PORTAL_ID }}
+          SMTP_HOST:            ${{ secrets.SMTP_HOST }}
+          SMTP_PORT:            ${{ secrets.SMTP_PORT }}
+          SMTP_USER:            ${{ secrets.SMTP_USER }}
+          SMTP_PASS:            ${{ secrets.SMTP_PASS }}
+          SMTP_SECURE:          ${{ secrets.SMTP_SECURE }}
+          MAIL_FROM:            ${{ secrets.MAIL_FROM }}
+          A2A_TEST_MODE:        "0"
         run: python -m core.orchestrator
 
       - name: Upload exports

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ flowchart LR
 
 PDF generation relies on WeasyPrint system libraries, installed by the Dockerfile and the CI workflow.
 
+## Google OAuth & Token Rotation
+
+The refresh token is bound to the exact client (ID/secret); mixing clients causes `invalid_grant` errors. To re-issue a refresh token, generate a consent URL with `access_type=offline` and `prompt=consent`. The helper accepts the legacy `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`, the v2 variants `GOOGLE_CLIENT_ID_V2`/`GOOGLE_CLIENT_SECRET_V2`, or a full JSON blob via `GOOGLE_OAUTH_JSON`.
+
 ## Workflow Description
 
 1. Poll Google Calendar and Contacts for new entries containing trigger words.
@@ -174,8 +178,13 @@ CRM.
 | `TRIGGER_WORDS_FILE` | Path to trigger words list | `config/trigger_words.txt` |
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID | – |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | – |
+| `GOOGLE_CLIENT_ID_V2` | Alternate client ID (auto-detected) | – |
+| `GOOGLE_CLIENT_SECRET_V2` | Alternate client secret (auto-detected) | – |
 | `GOOGLE_REFRESH_TOKEN` | Google OAuth refresh token | – |
-| `GOOGLE_CALENDAR_ID` | Calendar ID to poll | `primary` |
+| `GOOGLE_OAUTH_JSON` | Full client JSON blob | – |
+| `GOOGLE_CALENDAR_IDS` | Comma-separated calendar IDs to poll | `primary` |
+| `CAL_LOOKAHEAD_DAYS` | Days ahead to fetch events | `14` |
+| `CAL_LOOKBACK_DAYS` | Days back to include events | `1` |
 | `HUBSPOT_ACCESS_TOKEN` | HubSpot private app token | – |
 | `USE_PUSH_TRIGGERS` | Disable scheduled polling | `false` |
 | `ENABLE_PRO_SOURCES` | Allow pro research agents | `false` |

--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import os
-import re
-from datetime import datetime, timedelta, timezone
+import os, re
+import datetime as dt
 from typing import Any, Dict, List
 
 from core.utils import log_step
-from .google_oauth import build_user_credentials, which_variant
+from .google_oauth import build_user_credentials, which_variant, classify_oauth_error
 
 try:
     from google.oauth2.credentials import Credentials
@@ -17,6 +16,38 @@ except Exception:
     build = None
 
 Normalized = Dict[str, Any]
+
+LOOKAHEAD_DAYS = int(os.getenv("CAL_LOOKAHEAD_DAYS", "14"))
+LOOKBACK_DAYS = int(os.getenv("CAL_LOOKBACK_DAYS", "1"))
+CAL_IDS = [c.strip() for c in os.getenv("GOOGLE_CALENDAR_IDS", "primary").split(",") if c.strip()]
+SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+
+
+def _time_window() -> tuple[str, str]:
+    now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+    tmin = now - dt.timedelta(days=LOOKBACK_DAYS)
+    tmax = now + dt.timedelta(days=LOOKAHEAD_DAYS)
+    return tmin.isoformat(), tmax.isoformat()
+
+
+def _normalize(ev: Dict[str, Any], cal_id: str) -> Normalized:
+    return {
+        "event_id": ev.get("id"),
+        "summary": ev.get("summary"),
+        "description": ev.get("description"),
+        "location": ev.get("location"),
+        "attendees": [
+            {"email": a.get("email")}
+            for a in ev.get("attendees", []) or []
+            if isinstance(a, dict)
+        ],
+        "start": ev.get("start"),
+        "end": ev.get("end"),
+        "creatorEmail": (ev.get("creator") or {}).get("email"),
+        "creator": ev.get("creator"),
+        "calendarId": cal_id,
+    }
+
 
 # ---------- Hilfsfunktionen für Triggerprüfung etc. ----------
 COMPANY_REGEX = r"\b([A-Z][A-Za-z0-9&.\- ]{2,}\s(?:GmbH|AG|KG|SE|Ltd|Inc|LLC))\b"
@@ -48,21 +79,8 @@ def extract_domain(text: str) -> str | None:
 
 
 # ---------- Hauptfunktion fetch_events ----------
-SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
-
 def fetch_events() -> List[Normalized]:
-    """Fetch events from Google Calendar API within the configured time window."""
-
-    now = datetime.now(timezone.utc)
-    minutes_back = int(os.getenv("CALENDAR_MINUTES_BACK", "1440"))  # 24h
-    minutes_fwd = int(os.getenv("CALENDAR_MINUTES_FWD", "10080"))  # 7d
-    time_min = (now - timedelta(minutes=minutes_back)).isoformat()
-    time_max = (now + timedelta(minutes=minutes_fwd)).isoformat()
-
-    log_step("calendar", "fetch_call", {"time_min": time_min, "time_max": time_max})
-
-    events_result: Dict[str, Any] = {}
-    items: List[Dict[str, Any]] = []
+    results: List[Normalized] = []
     try:
         if build:
             creds = build_user_credentials(SCOPES)
@@ -74,66 +92,36 @@ def fetch_events() -> List[Normalized]:
                     severity="error",
                 )
                 return []
-            service = build(
-                "calendar", "v3", credentials=creds, cache_discovery=False
-            )
-
-            events_result = (
-                service.events()
-                .list(
-                    calendarId="primary",
-                    timeMin=time_min,
-                    timeMax=time_max,
-                    singleEvents=True,
-                    orderBy="startTime",
-                )
-                .execute()
-            )
-            items = events_result.get("items", [])
-        else:
-            log_step(
-                "calendar",
-                "fetch_error",
-                {"error": "google libraries not available"},
-                severity="critical",
-            )
-    except Exception as e:
-        log_step("calendar", "fetch_error", {"error": str(e)}, severity="critical")
-
-    log_step("calendar", "raw_api_response", {"response": events_result})
-
-    results: List[Dict[str, Any]] = []
-    for ev in items:
-        results.append(
-            {
-                "event_id": ev.get("id"),
-                "summary": ev.get("summary"),
-                "description": ev.get("description"),
-                "location": ev.get("location"),
-                "attendees": [
-                    {"email": a.get("email")}
-                    for a in ev.get("attendees", []) or []
-                    if isinstance(a, dict)
-                ],
-                "start": ev.get("start"),
-                "end": ev.get("end"),
-                "creatorEmail": (ev.get("creator") or {}).get("email"),
-                "creator": ev.get("creator"),
-            }
+            service = build("calendar", "v3", credentials=creds, cache_discovery=False)
+            tmin, tmax = _time_window()
+            for cal_id in CAL_IDS:
+                token = None
+                while True:
+                    resp = (
+                        service.events()
+                        .list(
+                            calendarId=cal_id,
+                            timeMin=tmin,
+                            timeMax=tmax,
+                            singleEvents=True,
+                            orderBy="startTime",
+                            maxResults=2500,
+                            pageToken=token,
+                        )
+                        .execute()
+                    )
+                    for item in resp.get("items", []):
+                        results.append(_normalize(item, cal_id))
+                    token = resp.get("nextPageToken")
+                    if not token:
+                        break
+            log_step("calendar", "fetch_ok", {"calendars": CAL_IDS, "count": len(results)})
+    except Exception as e:  # pragma: no cover
+        code, hint = classify_oauth_error(e)
+        log_step(
+            "calendar",
+            "fetch_error",
+            {"error": str(e), "code": code, "hint": hint, "variant": which_variant()},
+            severity="error",
         )
-
-    # 📊 Normalisiertes Log mit Übersicht
-    log_step(
-        "calendar",
-        "fetched_events",
-        {
-            "count": len(results),
-            "time_min": time_min,
-            "time_max": time_max,
-            "ids": [ev.get("event_id") for ev in results],
-            "summaries": [ev.get("summary") for ev in results],
-            "creator_emails": [ev.get("creatorEmail") for ev in results],
-        },
-    )
-
     return results

--- a/integrations/google_oauth.py
+++ b/integrations/google_oauth.py
@@ -1,24 +1,26 @@
-"""Unified Google OAuth env handling (v1, v2, JSON)."""
+"""Centralized Google OAuth handling for v1/v2/JSON envs with helpful error mapping."""
 from __future__ import annotations
 import os, json
-from typing import Optional, List
+from typing import Optional, List, Tuple
 
 try:
     from google.oauth2.credentials import Credentials  # type: ignore
 except Exception:  # pragma: no cover
     Credentials = None  # type: ignore
 
-DEFAULT_TOKEN_URI = os.getenv("GOOGLE_TOKEN_URI", "https://oauth2.googleapis.com/token")
+DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token"
 
-def _first(*keys: str) -> Optional[str]:
+
+def _env_first(*keys: str) -> Optional[str]:
     for k in keys:
         v = os.getenv(k)
         if v:
             return v
     return None
 
-def _maybe_parse_json_env() -> dict:
-    raw = _first("GOOGLE_OAUTH_JSON", "GOOGLE_CREDENTIALS_JSON", "GOOGLE_0")
+
+def _json_blob() -> dict:
+    raw = _env_first("GOOGLE_OAUTH_JSON", "GOOGLE_CREDENTIALS_JSON", "GOOGLE_0")
     if not raw:
         return {}
     try:
@@ -27,16 +29,25 @@ def _maybe_parse_json_env() -> dict:
     except Exception:
         return {}
 
+
+def which_variant() -> str:
+    if os.getenv("GOOGLE_CLIENT_ID_V2") or os.getenv("GOOGLE_CLIENT_SECRET_V2"):
+        return "v2"
+    if os.getenv("GOOGLE_0") or os.getenv("GOOGLE_OAUTH_JSON") or os.getenv("GOOGLE_CREDENTIALS_JSON"):
+        return "json"
+    return "v1"
+
+
 def build_user_credentials(scopes: List[str]) -> Optional["Credentials"]:
-    """Return Credentials or None if incomplete/unsupported environment."""
-    if Credentials is None:  # libs not installed in test env
+    """Build Credentials from v1 or v2 env names, or a JSON blob. Returns None if incomplete."""
+    if Credentials is None:
         return None
 
-    blob = _maybe_parse_json_env()
-    client_id = _first("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_ID_V2") or blob.get("client_id")
-    client_secret = _first("GOOGLE_CLIENT_SECRET", "GOOGLE_CLIENT_SECRET_V2") or blob.get("client_secret")
-    refresh_token = _first("GOOGLE_REFRESH_TOKEN")
-    token_uri = _first("GOOGLE_TOKEN_URI") or blob.get("token_uri") or DEFAULT_TOKEN_URI
+    blob = _json_blob()
+    client_id = _env_first("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_ID_V2") or blob.get("client_id")
+    client_secret = _env_first("GOOGLE_CLIENT_SECRET", "GOOGLE_CLIENT_SECRET_V2") or blob.get("client_secret")
+    refresh_token = _env_first("GOOGLE_REFRESH_TOKEN") or blob.get("refresh_token")
+    token_uri = _env_first("GOOGLE_TOKEN_URI") or blob.get("token_uri") or DEFAULT_TOKEN_URI
 
     if not (client_id and client_secret and refresh_token):
         return None
@@ -50,9 +61,21 @@ def build_user_credentials(scopes: List[str]) -> Optional["Credentials"]:
         scopes=scopes or None,
     )
 
-def which_variant() -> str:
-    if os.getenv("GOOGLE_CLIENT_ID_V2") or os.getenv("GOOGLE_CLIENT_SECRET_V2"):
-        return "v2"
-    if os.getenv("GOOGLE_0") or os.getenv("GOOGLE_OAUTH_JSON") or os.getenv("GOOGLE_CREDENTIALS_JSON"):
-        return "json"
-    return "v1"
+
+def classify_oauth_error(err: Exception) -> Tuple[str, str]:
+    """Return (code, human_hint)."""
+    msg = str(err).lower()
+    if "invalid_grant" in msg:
+        return (
+            "invalid_grant",
+            "Refresh token is expired/revoked OR does not belong to this client. "
+            "Re-issue consent using the SAME client (access_type=offline, prompt=consent).",
+        )
+    if "invalid_client" in msg:
+        return ("invalid_client", "Client ID/secret mismatch; check env and GitHub secrets mapping.")
+    if "unauthorized_client" in msg:
+        return ("unauthorized_client", "Client not allowed for this flow/scope in Cloud Console.")
+    if "invalid_scope" in msg:
+        return ("invalid_scope", "Requested scopes not enabled/approved; check Calendar/People scopes.")
+    return ("unknown_oauth_error", "See full exception in logs; enable verbose logging if needed.")
+

--- a/tests/test_google_oauth_env_mapping.py
+++ b/tests/test_google_oauth_env_mapping.py
@@ -1,39 +1,33 @@
 import os
-from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-from integrations.google_oauth import build_user_credentials
+from integrations.google_oauth import build_user_credentials, classify_oauth_error
 
 SCOPES = ["x"]
 
-def _clear(keys):
-    for k in keys:
-        os.environ.pop(k, None)
+
+def _clear():
+    for k in list(os.environ.keys()):
+        if k.startswith("GOOGLE_"):
+            os.environ.pop(k, None)
+
+
+def test_v1_names_work(monkeypatch):
+    _clear()
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "sec")
+    monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "rt")
+    assert build_user_credentials(SCOPES) is not None
+
 
 def test_v2_names_work(monkeypatch):
-    _clear([
-        "GOOGLE_CLIENT_ID",
-        "GOOGLE_CLIENT_SECRET",
-        "GOOGLE_REFRESH_TOKEN",
-        "GOOGLE_CLIENT_ID_V2",
-        "GOOGLE_CLIENT_SECRET_V2",
-    ])
+    _clear()
     monkeypatch.setenv("GOOGLE_CLIENT_ID_V2", "id")
     monkeypatch.setenv("GOOGLE_CLIENT_SECRET_V2", "sec")
     monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "rt")
     assert build_user_credentials(SCOPES) is not None
 
-def test_v1_names_work(monkeypatch):
-    _clear([
-        "GOOGLE_CLIENT_ID",
-        "GOOGLE_CLIENT_SECRET",
-        "GOOGLE_REFRESH_TOKEN",
-        "GOOGLE_CLIENT_ID_V2",
-        "GOOGLE_CLIENT_SECRET_V2",
-    ])
-    monkeypatch.setenv("GOOGLE_CLIENT_ID", "id")
-    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "sec")
-    monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "rt")
-    assert build_user_credentials(SCOPES) is not None
+
+def test_invalid_grant_hint():
+    code, hint = classify_oauth_error(Exception("invalid_grant: expired"))
+    assert code == "invalid_grant"
+    assert "Refresh token" in hint
+

--- a/tests/unit/test_orchestrator_exit.py
+++ b/tests/unit/test_orchestrator_exit.py
@@ -8,5 +8,6 @@ def test_main_handles_string_exit(monkeypatch):
         raise SystemExit("No real calendar events detected – aborting run")
 
     monkeypatch.setattr(orchestrator, "run", fake_run)
+    monkeypatch.setattr(orchestrator, "build_user_credentials", lambda scopes: object())
     rc = orchestrator.main([])
     assert rc == 0


### PR DESCRIPTION
## Summary
- centralize Google OAuth handling with v1/v2/JSON env support and actionable error hints
- fetch calendar events across multiple IDs with robust windowing and pagination
- preflight OAuth credentials and document new env vars and CI mappings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b527c178ec832bbded0c926ab0f955