### PR TITLE
refactor: enforce v2-only Google OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,8 @@
 # === Google OAuth (People API + Calendar) ===
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-# Alternative names (auto-detected; you do not need both):
 GOOGLE_CLIENT_ID_V2=
 GOOGLE_CLIENT_SECRET_V2=
 GOOGLE_REFRESH_TOKEN=
 GOOGLE_TOKEN_URI=https://oauth2.googleapis.com/token
-# Optional: full client JSON as a single env var (stringified JSON):
-# GOOGLE_OAUTH_JSON=
 
 # === HubSpot ===
 HUBSPOT_ACCESS_TOKEN=

--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -90,11 +90,11 @@ jobs:
 
       - name: Run orchestrator (LIVE)
         env:
-          GOOGLE_CLIENT_ID:     ${{ secrets.GOOGLE_CLIENT_ID || secrets.GOOGLE_CLIENT_ID_V2 }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET || secrets.GOOGLE_CLIENT_SECRET_V2 }}
-          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
-          GOOGLE_TOKEN_URI:     ${{ secrets.GOOGLE_TOKEN_URI || 'https://oauth2.googleapis.com/token' }}
-          GOOGLE_CALENDAR_IDS:  ${{ secrets.GOOGLE_CALENDAR_IDS || 'primary' }}
+          GOOGLE_CLIENT_ID_V2:     ${{ secrets.GOOGLE_CLIENT_ID_V2 }}
+          GOOGLE_CLIENT_SECRET_V2: ${{ secrets.GOOGLE_CLIENT_SECRET_V2 }}
+          GOOGLE_REFRESH_TOKEN:    ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+          GOOGLE_TOKEN_URI:        ${{ secrets.GOOGLE_TOKEN_URI || 'https://oauth2.googleapis.com/token' }}
+          GOOGLE_CALENDAR_IDS:     ${{ secrets.GOOGLE_CALENDAR_IDS || 'primary' }}
           CAL_LOOKAHEAD_DAYS:   30
           CAL_LOOKBACK_DAYS:    2
           HUBSPOT_ACCESS_TOKEN: ${{ secrets.HUBSPOT_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ flowchart LR
    docker compose -f ops/docker-compose.yml up
    ```
 3. For scheduled runs via GitHub Actions, define repository secrets:
-   - `GOOGLE_CLIENT_ID`
-   - `GOOGLE_CLIENT_SECRET`
+   - `GOOGLE_CLIENT_ID_V2`
+   - `GOOGLE_CLIENT_SECRET_V2`
    - `GOOGLE_REFRESH_TOKEN`
    - `HUBSPOT_ACCESS_TOKEN`
    - `HUBSPOT_PORTAL_ID`
@@ -55,7 +55,7 @@ PDF generation relies on WeasyPrint system libraries, installed by the Dockerfil
 
 ## Google OAuth & Token Rotation
 
-The refresh token is bound to the exact client (ID/secret); mixing clients causes `invalid_grant` errors. To re-issue a refresh token, generate a consent URL with `access_type=offline` and `prompt=consent`. The helper accepts the legacy `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`, the v2 variants `GOOGLE_CLIENT_ID_V2`/`GOOGLE_CLIENT_SECRET_V2`, or a full JSON blob via `GOOGLE_OAUTH_JSON`.
+The refresh token is bound to the exact client (ID/secret); mixing clients causes `invalid_grant` errors. To re-issue a refresh token, generate a consent URL with `access_type=offline` and `prompt=consent`. Only the v2 client (`GOOGLE_CLIENT_ID_V2`/`GOOGLE_CLIENT_SECRET_V2`) is supported.
 
 ## LIVE mode
 
@@ -180,12 +180,9 @@ CRM.
 | `ALLOWLIST_EMAIL_DOMAIN` | Allow reminder emails only to addresses in this domain | – |
 | `MAIL_TO` | Recipient e‑mail for reports | – |
 | `TRIGGER_WORDS_FILE` | Path to trigger words list | `config/trigger_words.txt` |
-| `GOOGLE_CLIENT_ID` | Google OAuth client ID | – |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | – |
-| `GOOGLE_CLIENT_ID_V2` | Alternate client ID (auto-detected) | – |
-| `GOOGLE_CLIENT_SECRET_V2` | Alternate client secret (auto-detected) | – |
+| `GOOGLE_CLIENT_ID_V2` | Google OAuth client ID | – |
+| `GOOGLE_CLIENT_SECRET_V2` | Google OAuth client secret | – |
 | `GOOGLE_REFRESH_TOKEN` | Google OAuth refresh token | – |
-| `GOOGLE_OAUTH_JSON` | Full client JSON blob | – |
 | `GOOGLE_CALENDAR_IDS` | Comma-separated calendar IDs to poll | `primary` |
 | `CAL_LOOKAHEAD_DAYS` | Days ahead to fetch events | `14` |
 | `CAL_LOOKBACK_DAYS` | Days back to include events | `1` |

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -57,8 +57,8 @@ def _assert_live_ready() -> None:
         return
     required = [
         "GOOGLE_REFRESH_TOKEN",
-        "GOOGLE_CLIENT_ID",
-        "GOOGLE_CLIENT_SECRET",
+        "GOOGLE_CLIENT_ID_V2",
+        "GOOGLE_CLIENT_SECRET_V2",
         "SMTP_HOST",
         "SMTP_PORT",
         "MAIL_FROM",

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -19,7 +19,7 @@ from core.utils import (
 )  # noqa: F401  # required_fields/optional_fields imported for completeness
 from integrations.google_calendar import fetch_events
 from integrations.google_contacts import fetch_contacts
-from integrations.google_oauth import build_user_credentials, which_variant
+from integrations.google_oauth import build_user_credentials
 from core.trigger_words import contains_trigger
 
 # Expose integrations so tests can monkeypatch them
@@ -48,6 +48,7 @@ _spec.loader.exec_module(_mod)
 append_jsonl = _mod.append
 
 CAL_SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+GOOGLE_OAUTH_VARIANT = "v2"
 
 
 # --------- LIVE readiness assertions ---------
@@ -107,9 +108,9 @@ def log_event(record: Dict[str, Any]) -> None:
 def _preflight_google() -> bool:
     creds = build_user_credentials(CAL_SCOPES)
     if not creds:
-        log_event({"status": "preflight_oauth_missing", "provider": "google", "variant": which_variant()})
+        log_event({"status": "preflight_oauth_missing", "provider": "google", "variant": GOOGLE_OAUTH_VARIANT})
         return False
-    log_event({"status": "preflight_oauth_ok", "provider": "google", "variant": which_variant()})
+    log_event({"status": "preflight_oauth_ok", "provider": "google", "variant": GOOGLE_OAUTH_VARIANT})
     return True
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -22,11 +22,7 @@ import importlib.util as _ilu
 import glob
 import shutil
 
-try:  # pragma: no cover - optional dependency
-    from integrations.google_oauth import which_variant as _which_variant
-except Exception:  # pragma: no cover
-    def _which_variant() -> str:
-        return "unknown"
+VARIANT = "v2"
 
 _JSONL_PATH = Path(__file__).resolve().parents[1] / "logging" / "jsonl_sink.py"
 _spec = _ilu.spec_from_file_location("jsonl_sink", _JSONL_PATH)
@@ -81,7 +77,7 @@ def log_step(source: str, stage: str, data: Dict[str, Any], *, severity: str = "
         "trigger_source": source,
         "status": stage,
         "severity": severity,
-        "variant": _which_variant(),
+        "variant": VARIANT,
     }
     payload.update(data)
     try:

--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -6,7 +6,7 @@ import datetime as dt
 from typing import Any, Dict, List
 
 from core.utils import log_step
-from .google_oauth import build_user_credentials, which_variant, classify_oauth_error
+from .google_oauth import build_user_credentials, classify_oauth_error
 
 try:
     from google.oauth2.credentials import Credentials
@@ -88,7 +88,7 @@ def fetch_events() -> List[Normalized]:
                 log_step(
                     "calendar",
                     "missing_google_oauth_env",
-                    {"variant": which_variant()},
+                    {},
                     severity="error",
                 )
                 return []
@@ -100,7 +100,7 @@ def fetch_events() -> List[Normalized]:
                 log_step(
                     "calendar",
                     "fetch_error",
-                    {"error": str(e), "code": code, "hint": hint, "variant": which_variant()},
+                    {"error": str(e), "code": code, "hint": hint},
                     severity="error",
                 )
                 return []
@@ -132,7 +132,7 @@ def fetch_events() -> List[Normalized]:
         log_step(
             "calendar",
             "fetch_error",
-            {"error": str(e), "code": code, "hint": hint, "variant": which_variant()},
+            {"error": str(e), "code": code, "hint": hint},
             severity="error",
         )
     return results

--- a/integrations/google_contacts.py
+++ b/integrations/google_contacts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Callable
-from .google_oauth import build_user_credentials, which_variant, classify_oauth_error
+from .google_oauth import build_user_credentials, classify_oauth_error
 
 # Google libs optional in Tests
 try:  # pragma: no cover
@@ -69,7 +69,7 @@ def fetch_contacts(page_size: int = 200, page_limit: int = 10) -> List[Dict[str,
             log_step(
                 "contacts",
                 "missing_google_oauth_env",
-                {"variant": which_variant()},
+                {},
                 severity="error",
             )
             return []
@@ -111,7 +111,7 @@ def fetch_contacts(page_size: int = 200, page_limit: int = 10) -> List[Dict[str,
         log_step(
             "contacts",
             "fetch_error",
-            {"error": str(e), "code": code, "hint": hint, "variant": which_variant()},
+            {"error": str(e), "code": code, "hint": hint},
             severity="error",
         )
         return []

--- a/integrations/google_oauth.py
+++ b/integrations/google_oauth.py
@@ -1,57 +1,27 @@
-"""Centralized Google OAuth handling for v1/v2/JSON envs with helpful error mapping."""
+"""Google OAuth (v2-only): requires GOOGLE_CLIENT_ID_V2 / GOOGLE_CLIENT_SECRET_V2 / GOOGLE_REFRESH_TOKEN."""
 from __future__ import annotations
-import os, json
+import os
 from typing import Optional, List, Tuple
 
 try:
     from google.oauth2.credentials import Credentials  # type: ignore
-except Exception:  # pragma: no cover
+except Exception:
     Credentials = None  # type: ignore
 
 DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token"
 
-
-def _env_first(*keys: str) -> Optional[str]:
-    for k in keys:
-        v = os.getenv(k)
-        if v:
-            return v
-    return None
-
-
-def _json_blob() -> dict:
-    raw = _env_first("GOOGLE_OAUTH_JSON", "GOOGLE_CREDENTIALS_JSON", "GOOGLE_0")
-    if not raw:
-        return {}
-    try:
-        j = json.loads(raw)
-        return j.get("installed") or j.get("web") or j
-    except Exception:
-        return {}
-
-
-def which_variant() -> str:
-    if os.getenv("GOOGLE_CLIENT_ID_V2") or os.getenv("GOOGLE_CLIENT_SECRET_V2"):
-        return "v2"
-    if os.getenv("GOOGLE_0") or os.getenv("GOOGLE_OAUTH_JSON") or os.getenv("GOOGLE_CREDENTIALS_JSON"):
-        return "json"
-    return "v1"
-
-
 def build_user_credentials(scopes: List[str]) -> Optional["Credentials"]:
-    """Build Credentials from v1 or v2 env names, or a JSON blob. Returns None if incomplete."""
     if Credentials is None:
         return None
-
-    blob = _json_blob()
-    client_id = _env_first("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_ID_V2") or blob.get("client_id")
-    client_secret = _env_first("GOOGLE_CLIENT_SECRET", "GOOGLE_CLIENT_SECRET_V2") or blob.get("client_secret")
-    refresh_token = _env_first("GOOGLE_REFRESH_TOKEN") or blob.get("refresh_token")
-    token_uri = _env_first("GOOGLE_TOKEN_URI") or blob.get("token_uri") or DEFAULT_TOKEN_URI
-
+    client_id = os.getenv("GOOGLE_CLIENT_ID_V2")
+    client_secret = os.getenv("GOOGLE_CLIENT_SECRET_V2")
+    refresh_token = os.getenv("GOOGLE_REFRESH_TOKEN")
+    token_uri = os.getenv("GOOGLE_TOKEN_URI", DEFAULT_TOKEN_URI)
     if not (client_id and client_secret and refresh_token):
         return None
-
+    # Hard block if legacy vars are present to avoid accidental mixing.
+    if os.getenv("GOOGLE_CLIENT_ID") or os.getenv("GOOGLE_CLIENT_SECRET") or os.getenv("GOOGLE_0") or os.getenv("GOOGLE_OAUTH_JSON") or os.getenv("GOOGLE_CREDENTIALS_JSON"):
+        raise RuntimeError("Legacy Google OAuth variables detected; v2-only is enforced. Remove legacy envs.")
     return Credentials(
         token=None,
         refresh_token=refresh_token,
@@ -61,21 +31,17 @@ def build_user_credentials(scopes: List[str]) -> Optional["Credentials"]:
         scopes=scopes or None,
     )
 
-
 def classify_oauth_error(err: Exception) -> Tuple[str, str]:
-    """Return (code, human_hint)."""
     msg = str(err).lower()
     if "invalid_grant" in msg:
-        return (
-            "invalid_grant",
-            "Refresh token is expired/revoked OR does not belong to this client. "
-            "Re-issue consent using the SAME client (access_type=offline, prompt=consent).",
-        )
+        return ("invalid_grant",
+                "Refresh token expired/revoked or not issued for this v2 client. "
+                "Ensure Consent Screen is IN PRODUCTION and re-issue with the same v2 client "
+                "(access_type=offline, prompt=consent).")
     if "invalid_client" in msg:
-        return ("invalid_client", "Client ID/secret mismatch; check env and GitHub secrets mapping.")
+        return ("invalid_client", "Check GOOGLE_CLIENT_ID_V2 / GOOGLE_CLIENT_SECRET_V2 values.")
     if "unauthorized_client" in msg:
-        return ("unauthorized_client", "Client not allowed for this flow/scope in Cloud Console.")
+        return ("unauthorized_client", "Client not allowed for scopes; verify Cloud Console settings.")
     if "invalid_scope" in msg:
-        return ("invalid_scope", "Requested scopes not enabled/approved; check Calendar/People scopes.")
-    return ("unknown_oauth_error", "See full exception in logs; enable verbose logging if needed.")
-
+        return ("invalid_scope", "Enable Calendar/People scopes on the consent screen.")
+    return ("unknown_oauth_error", "See full exception in logs.")

--- a/ops/CONFIG.md
+++ b/ops/CONFIG.md
@@ -5,11 +5,10 @@ See repository README for common variables.
 
 ## Secrets
 - `HUBSPOT_ACCESS_TOKEN`
-- Erforderlich: `GOOGLE_CLIENT_ID` **oder** `GOOGLE_CLIENT_ID_V2`
-  `GOOGLE_CLIENT_SECRET` **oder** `GOOGLE_CLIENT_SECRET_V2`
-  `GOOGLE_REFRESH_TOKEN`
-- Optional:    `GOOGLE_TOKEN_URI` (Default: https://oauth2.googleapis.com/token)
-  `GOOGLE_OAUTH_JSON` (alternativ gesamtes JSON)
+- `GOOGLE_CLIENT_ID_V2`
+- `GOOGLE_CLIENT_SECRET_V2`
+- `GOOGLE_REFRESH_TOKEN`
+- Optional: `GOOGLE_TOKEN_URI` (Default: https://oauth2.googleapis.com/token)
 - `SMTP_HOST` (optional)
 - `SMTP_USER` (optional)
 - `SMTP_PASS` (optional)

--- a/tests/test_google_oauth_env_mapping.py
+++ b/tests/test_google_oauth_env_mapping.py
@@ -10,12 +10,12 @@ def _clear():
             os.environ.pop(k, None)
 
 
-def test_v1_names_work(monkeypatch):
+def test_v1_names_rejected(monkeypatch):
     _clear()
     monkeypatch.setenv("GOOGLE_CLIENT_ID", "id")
     monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "sec")
     monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "rt")
-    assert build_user_credentials(SCOPES) is not None
+    assert build_user_credentials(SCOPES) is None
 
 
 def test_v2_names_work(monkeypatch):

--- a/tests/test_live_enforcement.py
+++ b/tests/test_live_enforcement.py
@@ -2,7 +2,7 @@ import os, importlib, pytest
 
 def test_live_guard_fails_without_env(monkeypatch):
     monkeypatch.setenv("LIVE_MODE","1")
-    for k in ["GOOGLE_CLIENT_ID","GOOGLE_CLIENT_SECRET","GOOGLE_REFRESH_TOKEN","SMTP_HOST","SMTP_PORT","MAIL_FROM","HUBSPOT_ACCESS_TOKEN"]:
+    for k in ["GOOGLE_CLIENT_ID_V2","GOOGLE_CLIENT_SECRET_V2","GOOGLE_REFRESH_TOKEN","SMTP_HOST","SMTP_PORT","MAIL_FROM","HUBSPOT_ACCESS_TOKEN"]:
         monkeypatch.delenv(k, raising=False)
     orch = importlib.import_module("core.orchestrator")
     with pytest.raises(Exception):


### PR DESCRIPTION
## Summary
- replace Google OAuth helper with v2-only implementation that rejects legacy env vars
- simplify logging by hardcoding OAuth variant and removing `which_variant`
- adjust Calendar/Contacts integrations and tests for v2-only flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b560a1089c832bbef88fc57c0c0cd5