### PR TITLE
CI: enforce v2-only OAuth env

### DIFF
--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -85,6 +85,17 @@ jobs:
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
 
+      - name: Assert v2-only env
+        run: python ops/assert_v2_only.py
+
+      - name: Google OAuth selftest (v2-only)
+        env:
+          GOOGLE_CLIENT_ID_V2:     ${{ secrets.GOOGLE_CLIENT_ID_V2 }}
+          GOOGLE_CLIENT_SECRET_V2: ${{ secrets.GOOGLE_CLIENT_SECRET_V2 }}
+          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+          GOOGLE_TOKEN_URI:     ${{ secrets.GOOGLE_TOKEN_URI || 'https://oauth2.googleapis.com/token' }}
+        run: python ops/google_oauth_selftest.py
+
       - name: No dummy content guard
         run: python ops/no_demo_guard.py
 

--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -93,7 +93,7 @@ jobs:
           GOOGLE_CLIENT_ID_V2:     ${{ secrets.GOOGLE_CLIENT_ID_V2 }}
           GOOGLE_CLIENT_SECRET_V2: ${{ secrets.GOOGLE_CLIENT_SECRET_V2 }}
           GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
-          GOOGLE_TOKEN_URI:     ${{ secrets.GOOGLE_TOKEN_URI || 'https://oauth2.googleapis.com/token' }}
+          GOOGLE_TOKEN_URI:     ${{ secrets.GOOGLE_TOKEN_URI }}
         run: python ops/google_oauth_selftest.py
 
       - name: No dummy content guard
@@ -104,7 +104,7 @@ jobs:
           GOOGLE_CLIENT_ID_V2:     ${{ secrets.GOOGLE_CLIENT_ID_V2 }}
           GOOGLE_CLIENT_SECRET_V2: ${{ secrets.GOOGLE_CLIENT_SECRET_V2 }}
           GOOGLE_REFRESH_TOKEN:    ${{ secrets.GOOGLE_REFRESH_TOKEN }}
-          GOOGLE_TOKEN_URI:        ${{ secrets.GOOGLE_TOKEN_URI || 'https://oauth2.googleapis.com/token' }}
+          GOOGLE_TOKEN_URI:        ${{ secrets.GOOGLE_TOKEN_URI }}
           GOOGLE_CALENDAR_IDS:     ${{ secrets.GOOGLE_CALENDAR_IDS || 'primary' }}
           CAL_LOOKAHEAD_DAYS:   30
           CAL_LOOKBACK_DAYS:    2

--- a/integrations/google_oauth.py
+++ b/integrations/google_oauth.py
@@ -16,7 +16,7 @@ def build_user_credentials(scopes: List[str]) -> Optional["Credentials"]:
     client_id = os.getenv("GOOGLE_CLIENT_ID_V2")
     client_secret = os.getenv("GOOGLE_CLIENT_SECRET_V2")
     refresh_token = os.getenv("GOOGLE_REFRESH_TOKEN")
-    token_uri = os.getenv("GOOGLE_TOKEN_URI", DEFAULT_TOKEN_URI)
+    token_uri = os.getenv("GOOGLE_TOKEN_URI") or DEFAULT_TOKEN_URI
     if not (client_id and client_secret and refresh_token):
         return None
     # Hard block if legacy vars are present to avoid accidental mixing.

--- a/ops/assert_v2_only.py
+++ b/ops/assert_v2_only.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+import os, sys
+bad = [k for k in ["GOOGLE_CLIENT_ID","GOOGLE_CLIENT_SECRET","GOOGLE_0","GOOGLE_OAUTH_JSON","GOOGLE_CREDENTIALS_JSON"] if os.getenv(k)]
+if bad:
+    print("❌ Legacy Google OAuth env present:", ", ".join(bad))
+    sys.exit(1)
+print("✅ v2-only env check passed.")

--- a/ops/google_oauth_selftest.py
+++ b/ops/google_oauth_selftest.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Basic runtime check for Google OAuth v2 credentials."""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from integrations.google_oauth import build_user_credentials, classify_oauth_error
+
+SCOPES = ["https://www.googleapis.com/auth/userinfo.email"]
+
+
+def main() -> int:
+    creds = build_user_credentials(SCOPES)
+    if creds is None:
+        print("❌ Missing Google OAuth v2 environment variables")
+        return 1
+    try:
+        from google.auth.transport.requests import Request
+        creds.refresh(Request())
+    except Exception as exc:  # pragma: no cover - network error conditions
+        code, hint = classify_oauth_error(exc)
+        print(f"❌ Google OAuth selftest failed ({code}): {hint}")
+        return 1
+    print("✅ Google OAuth selftest succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add script to assert no legacy Google OAuth env vars
- run v2-only OAuth selftest in CI

## Testing
- `python ops/assert_v2_only.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b710b0d0832ba41c05c0eca3c6f9