### PR TITLE
docs: remove legacy Google OAuth names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
-# === Google OAuth (People API + Calendar) ===
+# === Google OAuth (v2-only) ===
 GOOGLE_CLIENT_ID_V2=
 GOOGLE_CLIENT_SECRET_V2=
 GOOGLE_REFRESH_TOKEN=
 GOOGLE_TOKEN_URI=https://oauth2.googleapis.com/token
+# Legacy/JSON variants are unsupported and will cause a hard error.
 
 # === HubSpot ===
 HUBSPOT_ACCESS_TOKEN=

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ PDF generation relies on WeasyPrint system libraries, installed by the Dockerfil
 
 ## Google OAuth & Token Rotation
 
+> **Note:** <span style="color:red">v2-only</span> – legacy environment names (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` or JSON variants) will fail at startup.
+
 The refresh token is bound to the exact client (ID/secret); mixing clients causes `invalid_grant` errors. To re-issue a refresh token, generate a consent URL with `access_type=offline` and `prompt=consent`. Only the v2 client (`GOOGLE_CLIENT_ID_V2`/`GOOGLE_CLIENT_SECRET_V2`) is supported.
 
 ## LIVE mode

--- a/ops/CONFIG.md
+++ b/ops/CONFIG.md
@@ -3,6 +3,8 @@
 Document environment variables and secrets required for the workflow.
 See repository README for common variables.
 
+> **Note:** <span style="color:red">v2-only</span> – legacy environment names (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` or JSON variants) will fail at startup.
+
 ## Secrets
 - `HUBSPOT_ACCESS_TOKEN`
 - `GOOGLE_CLIENT_ID_V2`


### PR DESCRIPTION
## Summary
- clarify `.env.example` to mark Google OAuth as v2-only
- highlight in docs that legacy Google env vars or JSON clients hard fail

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b67b2a59d0832bbf0b2100c00b1780