### PR TITLE
Extract company and domain from calendar events

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -443,9 +443,13 @@ def run(
         event_id = payload.get("event_id")
         enriched: Dict[str, Any] | None = None
         if not payload.get("company_name"):
-            payload["company_name"] = extract_company(payload.get("summary")) or extract_company(payload.get("description"))
+            extracted_company = extract_company(payload.get("summary")) or extract_company(payload.get("description"))
+            if extracted_company:
+                payload["company_name"] = extracted_company
         if not payload.get("domain"):
-            payload["domain"] = extract_domain(payload.get("summary")) or extract_domain(payload.get("description"))
+            extracted_domain = extract_domain(payload.get("summary")) or extract_domain(payload.get("description"))
+            if extracted_domain:
+                payload["domain"] = extracted_domain
         if event_id:
             enriched = field_completion_agent.run(trig)
             if enriched:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -17,7 +17,7 @@ from core.utils import (
     get_workflow_id,
     bundle_logs_into_exports,
 )  # noqa: F401  # required_fields/optional_fields imported for completeness
-from integrations.google_calendar import fetch_events
+from integrations.google_calendar import fetch_events, extract_company, extract_domain
 from integrations.google_contacts import fetch_contacts
 from integrations.google_oauth import build_user_credentials
 from core.trigger_words import contains_trigger
@@ -442,6 +442,10 @@ def run(
         payload = trig.setdefault("payload", {})
         event_id = payload.get("event_id")
         enriched: Dict[str, Any] | None = None
+        if not payload.get("company_name"):
+            payload["company_name"] = extract_company(payload.get("summary")) or extract_company(payload.get("description"))
+        if not payload.get("domain"):
+            payload["domain"] = extract_domain(payload.get("summary")) or extract_domain(payload.get("description"))
         if event_id:
             enriched = field_completion_agent.run(trig)
             if enriched:

--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -31,10 +31,14 @@ def _time_window() -> tuple[str, str]:
 
 
 def _normalize(ev: Dict[str, Any], cal_id: str) -> Normalized:
+    summary = ev.get("summary") or ""
+    description = ev.get("description") or ""
+    company = extract_company(summary) or extract_company(description)
+    domain = extract_domain(summary) or extract_domain(description)
     return {
         "event_id": ev.get("id"),
-        "summary": ev.get("summary"),
-        "description": ev.get("description"),
+        "summary": summary or None,
+        "description": description or None,
         "location": ev.get("location"),
         "attendees": [
             {"email": a.get("email")}
@@ -46,6 +50,8 @@ def _normalize(ev: Dict[str, Any], cal_id: str) -> Normalized:
         "creatorEmail": (ev.get("creator") or {}).get("email"),
         "creator": ev.get("creator"),
         "calendarId": cal_id,
+        "company_name": company,
+        "domain": domain,
     }
 
 

--- a/tests/test_google_calendar.py
+++ b/tests/test_google_calendar.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from integrations import google_calendar
+
+
+def test_normalize_extracts_company_and_domain():
+    ev = {
+        "id": "1",
+        "summary": "Weekly sync",
+        "description": "ACME GmbH kickoff at acme.com",
+    }
+    norm = google_calendar._normalize(ev, "primary")
+    assert norm["company_name"] == "ACME GmbH"
+    assert norm["domain"] == "acme.com"


### PR DESCRIPTION
## Summary
- enrich Google Calendar normalization with company and domain extraction
- ensure orchestrator prepopulates company_name and domain before field completion
- add unit test for company and domain extraction

## Testing
- `pytest tests/test_google_calendar.py tests/test_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b70cb120e8832b8df9c6e5b3d6c6e5