### PR TITLE
Add recovery restart and abort handlers with resume logging

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -304,6 +304,7 @@ def run(
     hubspot_check_existing: Callable[[Any], Any] | None = lambda cid: None,
     duplicate_checker: Callable[[Dict[str, Any], Any], bool] | None = lambda rec, existing: False,
     company_id: Any | None = None,
+    restart_event_id: str | None = None,
 ) -> Dict[str, Any]:
     """Orchestrate the research workflow for provided triggers."""
 
@@ -648,6 +649,8 @@ def run(
 
     finalize_summary()
     bundle_logs_into_exports()
+    if restart_event_id:
+        log_event({"event_id": restart_event_id, "status": "resumed"})
     return consolidated
 
 

--- a/tests/unit/test_orchestrator_exit.py
+++ b/tests/unit/test_orchestrator_exit.py
@@ -1,6 +1,8 @@
 import pytest
+from pathlib import Path
 
 from core import orchestrator
+from agents import recovery_agent
 
 
 def test_main_handles_string_exit(monkeypatch):
@@ -12,3 +14,50 @@ def test_main_handles_string_exit(monkeypatch):
     monkeypatch.setenv("LIVE_MODE", "0")
     rc = orchestrator.main([])
     assert rc == 0
+
+
+def test_abort_cleans_temp_and_logs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    records = []
+    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+    tmp = Path("artifacts") / "42"
+    tmp.mkdir(parents=True, exist_ok=True)
+    (tmp / "data.json").write_text("x", encoding="utf-8")
+
+    recovery_agent.abort("42")
+
+    assert not tmp.exists()
+    assert any(r.get("status") == "aborted" and r.get("event_id") == "42" for r in records)
+
+
+def test_run_logs_resumed_on_restart(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(orchestrator, "finalize_summary", lambda: None)
+    monkeypatch.setattr(orchestrator, "bundle_logs_into_exports", lambda: None)
+    monkeypatch.setattr(orchestrator.reminder_service, "check_and_notify", lambda t: None)
+    monkeypatch.setattr(orchestrator.field_completion_agent, "run", lambda t: {})
+    monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
+    monkeypatch.setattr(orchestrator.email_reader, "fetch_replies", lambda: [])
+    monkeypatch.setattr(orchestrator, "_missing_required", lambda s, p: [])
+    monkeypatch.setattr(orchestrator, "extract_company", lambda x: None)
+    monkeypatch.setattr(orchestrator, "extract_domain", lambda x: None)
+
+    records = []
+    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+
+    trig = [{"payload": {"event_id": "42", "company_name": "Acme", "domain": "acme.com"}}]
+
+    orchestrator.run(
+        triggers=trig,
+        researchers=[],
+        pdf_renderer=lambda d, p: None,
+        csv_exporter=lambda d, p: None,
+        hubspot_upsert=lambda d: None,
+        hubspot_attach=lambda p, c: None,
+        hubspot_check_existing=lambda c: None,
+        duplicate_checker=lambda d, e: False,
+        company_id=None,
+        restart_event_id="42",
+    )
+
+    assert any(r.get("status") == "resumed" and r.get("event_id") == "42" for r in records)


### PR DESCRIPTION
## Summary
- add restart and abort helpers to recovery agent to re-run workflows or abort and clean temporary data
- log `resumed` status in orchestrator when a restart completes
- test abort cleanup and restart resume logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b743a4118c832b910c005d0420b1f5