### PR TITLE
Log missing Google API client and expand trigger words

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ flowchart LR
    ```bash
    pip install -r requirements.txt
    ```
+   Missing Google API libraries log a `google_api_client_missing` step for
+   Calendar and Contacts.
 3. Set required environment variables as needed. SMTP/IMAP/HubSpot/Google variables are listed in [`.env.example`](.env.example) and documented in [`ops/CONFIG.md`](ops/CONFIG.md).
 4. Adjust trigger words in `config/trigger_words.txt` or point `TRIGGER_WORDS_FILE` to a custom list.
 

--- a/config/trigger_words.txt
+++ b/config/trigger_words.txt
@@ -17,3 +17,6 @@ termin vorbereitung
 vorbereitung meeting
 kunden termin
 kundentermin
+customer meeting
+kundengespräch
+meetingpreparation

--- a/integrations/google_contacts.py
+++ b/integrations/google_contacts.py
@@ -63,6 +63,7 @@ def _notes_blob(person: Dict[str, Any]) -> str:
 def fetch_contacts(page_size: int = 200, page_limit: int = 10) -> List[Dict[str, Any]]:
     """Live-Fetch (in Tests typischerweise gemonkeypatched)."""
     if build is None or Request is None:  # pragma: no cover
+        log_step("contacts", "google_api_client_missing", {}, severity="error")
         return []
 
     try:

--- a/tests/test_trigger_words.py
+++ b/tests/test_trigger_words.py
@@ -1,5 +1,6 @@
 import pytest
-from core.trigger_words import contains_trigger
+import pytest
+from core.trigger_words import contains_trigger, load_trigger_words
 
 TRIGGERS = ["besuchsvorbereitung", "meeting"]
 
@@ -34,3 +35,21 @@ def test_two_typos_fallback():
 def test_no_trigger_match():
     ev = {"summary": "Lunch with colleagues"}
     assert not contains_trigger(ev, TRIGGERS)
+
+
+def test_customer_meeting_synonym():
+    load_trigger_words.cache_clear()
+    triggers = load_trigger_words()
+    ev = {"summary": "Customer-Meeting with ACME"}
+    assert contains_trigger(ev, triggers)
+
+
+def test_custom_trigger_file(tmp_path, monkeypatch):
+    fn = tmp_path / "triggers.txt"
+    fn.write_text("foo\nbar baz\n")
+    monkeypatch.setenv("TRIGGER_WORDS_FILE", str(fn))
+    from core import trigger_words as tw
+    tw.load_trigger_words.cache_clear()
+    triggers = tw.load_trigger_words()
+    assert {"foo", "bar baz", "bar-baz", "barbaz"}.issubset(set(triggers))
+    tw.load_trigger_words.cache_clear()


### PR DESCRIPTION
## Summary
- Log `google_api_client_missing` when Google libraries are absent in Calendar and Contacts integrations.
- Load trigger words from `config/trigger_words.txt` and generate simple hyphen/spacing variants.
- Document missing Google API library behaviour in README.

## Testing
- `PYTHONPATH=. pytest tests/test_trigger_words.py`
- `PYTHONPATH=. pytest tests/test_calendar_fetch.py tests/test_google_calendar.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7457090c4832ba49595da697a63d3