### PR TITLE
Respect final and pause statuses in event active check

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -163,9 +163,17 @@ def _latest_status(event_id: str) -> Optional[str]:
 
 
 def is_event_active(event_id: str) -> bool:
-    """Return True if ``event_id`` exists and last status is pending/pending_admin."""
+    """Return True if the latest status is final or paused for ``event_id``.
+
+    This uses ``_latest_status`` to retrieve the most recent workflow status for
+    the given ``event_id``.  Events that have reached a final state or are
+    paused awaiting input should not be reprocessed, so the function returns
+    ``True`` for statuses in ``FINAL_STATUSES`` or ``PAUSE_STATUSES``.  Only
+    events with other statuses (e.g. ``resumed``) return ``False`` and are
+    eligible for processing.
+    """
     status = _latest_status(event_id)
-    return status in {statuses.PENDING, statuses.PENDING_ADMIN}
+    return status in (statuses.FINAL_STATUSES | statuses.PAUSE_STATUSES)
 
 
 def _missing_required(source: str, payload: Dict[str, Any]) -> List[str]:

--- a/tests/unit/test_duplicate_check.py
+++ b/tests/unit/test_duplicate_check.py
@@ -2,10 +2,12 @@
 
 from pathlib import Path
 import sys
+import json
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from core.duplicate_check import is_duplicate
+from core.orchestrator import is_event_active
 
 
 def test_is_duplicate_detects_similarity():
@@ -18,3 +20,19 @@ def test_is_duplicate_rejects_different_names():
     record = {"name": "Acme"}
     existing = [{"name": "Different"}]
     assert is_duplicate(record, existing) is False
+
+
+def test_is_event_active_pending_vs_resumed(tmp_path, monkeypatch):
+    logs_dir = tmp_path / "logs" / "workflows"
+    logs_dir.mkdir(parents=True)
+    log_file = logs_dir / "wf-test.jsonl"
+
+    # Initial pending status means the event is considered active
+    log_file.write_text(json.dumps({"event_id": "1", "status": "pending"}) + "\n")
+    monkeypatch.chdir(tmp_path)
+    assert is_event_active("1") is True
+
+    # A subsequent resumed status should allow processing again
+    with log_file.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"event_id": "1", "status": "resumed"}) + "\n")
+    assert is_event_active("1") is False


### PR DESCRIPTION
## Summary
- Treat events as active when latest status is in final or pause sets
- Add unit test covering pending vs resumed scenarios for event activity

## Testing
- `pytest tests/unit/test_duplicate_check.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74c63cfa4832ba614f29f401c1bcb