### PR TITLE
Add trigger suggestion and confirmation email workflow

### DIFF
--- a/tests/test_trigger_words.py
+++ b/tests/test_trigger_words.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest
-from core.trigger_words import contains_trigger, load_trigger_words
+from core.trigger_words import contains_trigger, load_trigger_words, suggest_similar
 
 TRIGGERS = ["besuchsvorbereitung", "meeting"]
 
@@ -35,6 +35,10 @@ def test_two_typos_fallback():
 def test_no_trigger_match():
     ev = {"summary": "Lunch with colleagues"}
     assert not contains_trigger(ev, TRIGGERS)
+
+
+def test_suggest_similar_finds_close_trigger():
+    assert suggest_similar("planning rserch tomorrow") == ["research"]
 
 
 def test_customer_meeting_synonym():


### PR DESCRIPTION
## Summary
- add `suggest_similar` for fuzzy trigger suggestions
- send confirmation emails when contacts mention near-trigger words
- test trigger suggestion logic and contact confirmation flow

## Testing
- `python -m pytest tests/test_trigger_words.py -q`
- `python -m pytest tests/unit/test_google_polling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74e002b58832bb45127c82a68a429