### PR TITLE
Mirror calendar fetch errors in workflow log

### DIFF
--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -89,6 +89,7 @@ def fetch_events() -> List[Normalized]:
     results: List[Normalized] = []
     if not build or not Credentials:
         log_step("calendar", "google_api_client_missing", {}, severity="error")
+        log_event({"status": "google_api_client_missing", "severity": "error"})
         return results
     try:
         creds = build_user_credentials(SCOPES)
@@ -98,6 +99,13 @@ def fetch_events() -> List[Normalized]:
                 "missing_google_oauth_env",
                 {"mode": "v2-only"},
                 severity="error",
+            )
+            log_event(
+                {
+                    "status": "missing_google_oauth_env",
+                    "mode": "v2-only",
+                    "severity": "error",
+                }
             )
             return []
         service = build("calendar", "v3", credentials=creds, cache_discovery=False)

--- a/tests/unit/test_google_calendar_error_logging.py
+++ b/tests/unit/test_google_calendar_error_logging.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from integrations import google_calendar
+from core import orchestrator
+
+
+def test_fetch_events_logs_when_api_client_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    records = []
+    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+    monkeypatch.setattr(google_calendar, "build", None)
+    monkeypatch.setattr(google_calendar, "Credentials", None)
+
+    events = google_calendar.fetch_events()
+    assert events == []
+    assert any(r.get("status") == "google_api_client_missing" for r in records)
+
+
+def test_fetch_events_logs_when_oauth_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    records = []
+    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+    monkeypatch.setattr(google_calendar, "build", object())
+    monkeypatch.setattr(google_calendar, "Credentials", object)
+    monkeypatch.setattr(google_calendar, "build_user_credentials", lambda scopes: None)
+
+    events = google_calendar.fetch_events()
+    assert events == []
+    assert any(r.get("status") == "missing_google_oauth_env" for r in records)
+
+
+def test_gather_triggers_mirrors_calendar_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    records = []
+    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+    monkeypatch.setattr(orchestrator, "fetch_events", lambda: [])
+    monkeypatch.setattr(orchestrator, "fetch_contacts", lambda: [])
+    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: True)
+
+    orchestrator.log_step(
+        "calendar", "fetch_error", {"error": "boom"}, severity="error"
+    )
+
+    triggers = orchestrator.gather_triggers()
+    assert triggers == []
+    assert any(r.get("status") == "fetch_error" and r.get("error") == "boom" for r in records)


### PR DESCRIPTION
## Summary
- Log calendar OAuth and API client issues to the workflow log
- Mirror calendar log errors into workflow logs when no events fetched
- Add unit tests for calendar error logging and mirroring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75aeb7188832b97ca74709105e787