### PR TITLE
Log workflow events for Google contacts failures

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -334,6 +334,8 @@ def gather_triggers(
                     }
                 )
                 contacts = []
+        if not contacts:
+            log_event({"status": "no_contacts", "severity": "warning"})
         for c in contacts or []:
             t = _as_trigger_from_contact(c)
             if t:

--- a/integrations/google_contacts.py
+++ b/integrations/google_contacts.py
@@ -64,6 +64,8 @@ def fetch_contacts(page_size: int = 200, page_limit: int = 10) -> List[Dict[str,
     """Live-Fetch (in Tests typischerweise gemonkeypatched)."""
     if build is None or Request is None:  # pragma: no cover
         log_step("contacts", "google_api_client_missing", {}, severity="error")
+        from core.orchestrator import log_event
+        log_event({"status": "google_api_client_missing", "severity": "error"})
         return []
 
     try:
@@ -74,6 +76,14 @@ def fetch_contacts(page_size: int = 200, page_limit: int = 10) -> List[Dict[str,
                 "missing_google_oauth_env",
                 {"mode": "v2-only"},
                 severity="error",
+            )
+            from core.orchestrator import log_event
+            log_event(
+                {
+                    "status": "missing_google_oauth_env",
+                    "severity": "error",
+                    "mode": "v2-only",
+                }
             )
             return []
 
@@ -122,6 +132,17 @@ def fetch_contacts(page_size: int = 200, page_limit: int = 10) -> List[Dict[str,
             "fetch_error",
             {"error": str(e), "code": code, "hint": hint, "client_id_tail": cid_tail},
             severity="error",
+        )
+        from core.orchestrator import log_event
+        log_event(
+            {
+                "status": "contacts_fetch_error",
+                "error": str(e),
+                "code": code,
+                "hint": hint,
+                "client_id_tail": cid_tail,
+                "severity": "error",
+            }
         )
         return []
 

--- a/tests/unit/test_google_contacts_error_logging.py
+++ b/tests/unit/test_google_contacts_error_logging.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from integrations import google_contacts
+from core import orchestrator
+
+
+def test_fetch_contacts_logs_when_api_client_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    records = []
+    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+    monkeypatch.setattr(google_contacts, "build", None)
+    monkeypatch.setattr(google_contacts, "Request", None)
+
+    contacts = google_contacts.fetch_contacts()
+    assert contacts == []
+    assert any(r.get("status") == "google_api_client_missing" for r in records)
+
+
+def test_gather_triggers_logs_no_contacts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    records = []
+    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+    monkeypatch.setattr(orchestrator, "fetch_events", lambda: [])
+    monkeypatch.setattr(orchestrator, "fetch_contacts", lambda: [])
+    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: True)
+
+    triggers = orchestrator.gather_triggers()
+    assert triggers == []
+    assert any(r.get("status") == "no_contacts" for r in records)


### PR DESCRIPTION
## Summary
- log workflow events for missing Google API client, OAuth env, and fetch errors in contacts fetcher
- record `no_contacts` when contact poll returns nothing
- cover missing libs and empty contacts cases with tests

## Testing
- `pytest tests/unit/test_google_contacts_error_logging.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75d37f5b0832bb5cc93855126066e