### PR TITLE
Add explicit fetch diagnostics for calendar and contacts

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -74,7 +74,8 @@ def test_run_processes_event_missing_fields(monkeypatch, tmp_path):
     events = [{"id": "1", "event_id": "e1", "summary": "Research meeting"}]
     monkeypatch.setattr(orchestrator, "fetch_events", lambda: events)
     monkeypatch.setattr(orchestrator, "fetch_contacts", lambda: [])
-    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: True)
+    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: None)
+    monkeypatch.setattr(orchestrator, "_contacts_fetch_logged", lambda wf_id: None)
     monkeypatch.setattr(orchestrator.email_sender, "send_email", lambda *a, **k: None)
     monkeypatch.setattr(reminder_service, "check_and_notify", lambda t: None)
     monkeypatch.setattr(field_completion_agent, "run", lambda t: {"company_name": "ACME", "domain": "acme.com"})

--- a/tests/unit/test_google_calendar_error_logging.py
+++ b/tests/unit/test_google_calendar_error_logging.py
@@ -41,7 +41,8 @@ def test_gather_triggers_mirrors_calendar_error(tmp_path, monkeypatch):
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
     monkeypatch.setattr(orchestrator, "fetch_events", lambda: [])
     monkeypatch.setattr(orchestrator, "fetch_contacts", lambda: [])
-    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: True)
+    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: None)
+    monkeypatch.setattr(orchestrator, "_contacts_fetch_logged", lambda wf_id: None)
 
     orchestrator.log_step(
         "calendar", "fetch_error", {"error": "boom"}, severity="error"

--- a/tests/unit/test_google_contacts_error_logging.py
+++ b/tests/unit/test_google_contacts_error_logging.py
@@ -27,7 +27,8 @@ def test_gather_triggers_logs_no_contacts(tmp_path, monkeypatch):
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
     monkeypatch.setattr(orchestrator, "fetch_events", lambda: [])
     monkeypatch.setattr(orchestrator, "fetch_contacts", lambda: [])
-    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: True)
+    monkeypatch.setattr(orchestrator, "_calendar_fetch_logged", lambda wf_id: None)
+    monkeypatch.setattr(orchestrator, "_contacts_fetch_logged", lambda wf_id: None)
 
     triggers = orchestrator.gather_triggers()
     assert triggers == []


### PR DESCRIPTION
## Summary
- return explicit failure codes from `_calendar_fetch_logged`
- log calendar and contact fetch issues with detailed codes in `gather_triggers`
- add `_contacts_fetch_logged` and expand tests for all failure codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75eedebcc832b90a078a0815e1f4a