### PR TITLE
refactor: drive diagnostics from centralized settings

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class _Settings:
+    """Centralised runtime configuration loaded from environment variables."""
+
+    cal_lookback_days: int = field(
+        default_factory=lambda: int(os.getenv("CAL_LOOKBACK_DAYS", "1"))
+    )
+    cal_lookahead_days: int = field(
+        default_factory=lambda: int(os.getenv("CAL_LOOKAHEAD_DAYS", "14"))
+    )
+    google_calendar_ids: List[str] = field(
+        default_factory=lambda: [
+            c.strip()
+            for c in os.getenv("GOOGLE_CALENDAR_IDS", "primary").split(",")
+            if c.strip()
+        ]
+    )
+    contacts_page_size: int = field(
+        default_factory=lambda: int(os.getenv("CONTACTS_PAGE_SIZE", "200"))
+    )
+    contacts_page_limit: int = field(
+        default_factory=lambda: int(os.getenv("CONTACTS_PAGE_LIMIT", "10"))
+    )
+
+
+SETTINGS = _Settings()

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -17,6 +17,7 @@ from core.utils import (
     finalize_summary,
     get_workflow_id,
 )  # noqa: F401  # required_fields/optional_fields imported for completeness
+from config.settings import SETTINGS
 from integrations.google_calendar import fetch_events, extract_company, extract_domain
 from integrations.google_contacts import fetch_contacts
 from integrations.google_oauth import build_user_credentials
@@ -516,19 +517,15 @@ def run(
     triggers = filtered
 
     if not triggers:
+        details = {
+            "lookback_days": SETTINGS.cal_lookback_days,
+            "lookahead_days": SETTINGS.cal_lookahead_days,
+            "calendar_ids": SETTINGS.google_calendar_ids or ["primary"],
+        }
+        log_step("orchestrator", "no_triggers_diagnostics", details, severity="info")
         log_event({
             "status": "no_triggers_diagnostics",
-            "details": {
-                "window": {
-                    "lookback_days": int(os.getenv("CAL_LOOKBACK_DAYS", "1")),
-                    "lookahead_days": int(os.getenv("CAL_LOOKAHEAD_DAYS", "14")),
-                    "calendar_ids": [
-                        c.strip()
-                        for c in os.getenv("GOOGLE_CALENDAR_IDS", "primary").split(",")
-                        if c.strip()
-                    ],
-                }
-            },
+            "details": details,
             "severity": "info",
         })
         log_event({

--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -5,6 +5,7 @@ import os, re
 import datetime as dt
 from typing import Any, Dict, List
 
+from config.settings import SETTINGS
 from core.utils import log_step
 from .google_oauth import build_user_credentials, classify_oauth_error
 
@@ -17,9 +18,9 @@ except Exception:
 
 Normalized = Dict[str, Any]
 
-LOOKAHEAD_DAYS = int(os.getenv("CAL_LOOKAHEAD_DAYS", "14"))
-LOOKBACK_DAYS = int(os.getenv("CAL_LOOKBACK_DAYS", "1"))
-CAL_IDS = [c.strip() for c in os.getenv("GOOGLE_CALENDAR_IDS", "primary").split(",") if c.strip()]
+LOOKAHEAD_DAYS = SETTINGS.cal_lookahead_days
+LOOKBACK_DAYS = SETTINGS.cal_lookback_days
+CAL_IDS = SETTINGS.google_calendar_ids or ["primary"]
 SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
 
 

--- a/integrations/google_contacts.py
+++ b/integrations/google_contacts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 
 from typing import Any, Dict, List, Optional, Callable
+
+from config.settings import SETTINGS
 from .google_oauth import build_user_credentials, classify_oauth_error
 
 # Google libs optional in Tests
@@ -60,8 +62,14 @@ def _notes_blob(person: Dict[str, Any]) -> str:
     return notes
 
 
-def fetch_contacts(page_size: int = 200, page_limit: int = 10) -> List[Dict[str, Any]]:
+def fetch_contacts(
+    page_size: int | None = None, page_limit: int | None = None
+) -> List[Dict[str, Any]]:
     """Live-Fetch (in Tests typischerweise gemonkeypatched)."""
+    if page_size is None:
+        page_size = SETTINGS.contacts_page_size
+    if page_limit is None:
+        page_limit = SETTINGS.contacts_page_limit
     if build is None or Request is None:  # pragma: no cover
         log_step("contacts", "google_api_client_missing", {}, severity="error")
         from core.orchestrator import log_event


### PR DESCRIPTION
## Summary
- centralize calendar and contacts configuration in `config.settings`
- consume centralized settings in Google Calendar and Contacts integrations
- log no-triggers diagnostics via orchestrator using settings-derived window

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7755b3cc0832bbc77656e608ccc3c