### PR TITLE
feat: enhance admin digest with artifact metrics

### DIFF
--- a/agents/digest.py
+++ b/agents/digest.py
@@ -1,0 +1,22 @@
+from pathlib import Path, PurePath
+import json
+
+
+def send_daily_admin_digest(to: str):
+    p = Path("logs/workflows/summary.json")
+    if not p.exists(): 
+        return
+    s = json.loads(p.read_text(encoding="utf-8"))
+    lines = [
+        f"workflow_id: {s.get('workflow_id')}",
+        f"errors: {s.get('errors')}  warnings: {s.get('warnings')}",
+        f"reports_generated: {s.get('reports_generated')}  mails_sent: {s.get('mails_sent')}",
+    ]
+    ah = s.get("artifact_health") or {}
+    lines += [
+        f"pdf_ok: {ah.get('pdf_ok')}  pdf_size: {ah.get('pdf_size')}",
+        f"csv_ok: {ah.get('csv_ok')}  csv_rows: {ah.get('csv_rows')}  empty_run: {ah.get('empty_run')}",
+    ]
+    body = "\n".join(lines)
+    from integrations.email_sender import send_email
+    send_email(to=to, subject="A2A daily digest", body=body)

--- a/tests/unit/test_digest.py
+++ b/tests/unit/test_digest.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import sys
+import json
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agents import digest
+import integrations.email_sender as email_sender
+
+
+def test_send_daily_admin_digest_builds_body(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    summary = {
+        "workflow_id": "wf-123",
+        "errors": 2,
+        "warnings": 1,
+        "reports_generated": 3,
+        "mails_sent": 5,
+        "artifact_health": {
+            "pdf_ok": True,
+            "pdf_size": 123,
+            "csv_ok": True,
+            "csv_rows": 10,
+            "empty_run": False,
+        },
+    }
+    summary_path = Path("logs/workflows")
+    summary_path.mkdir(parents=True)
+    (summary_path / "summary.json").write_text(json.dumps(summary))
+
+    captured = {}
+
+    def fake_send_email(*, to, subject, body):
+        captured["to"] = to
+        captured["subject"] = subject
+        captured["body"] = body
+
+    monkeypatch.setattr(email_sender, "send_email", fake_send_email)
+
+    digest.send_daily_admin_digest("admin@example.com")
+
+    assert captured["to"] == "admin@example.com"
+    assert captured["subject"] == "A2A daily digest"
+    expected = (
+        "workflow_id: wf-123\n"
+        "errors: 2  warnings: 1\n"
+        "reports_generated: 3  mails_sent: 5\n"
+        "pdf_ok: True  pdf_size: 123\n"
+        "csv_ok: True  csv_rows: 10  empty_run: False"
+    )
+    assert captured["body"] == expected
+
+
+def test_send_daily_admin_digest_no_file(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    called = {"flag": False}
+
+    def fake_send_email(*, to, subject, body):
+        called["flag"] = True
+
+    monkeypatch.setattr(email_sender, "send_email", fake_send_email)
+
+    digest.send_daily_admin_digest("admin@example.com")
+
+    assert called["flag"] is False


### PR DESCRIPTION
## Summary
- add `send_daily_admin_digest` that reports workflow summary including artifact health
- cover admin digest behavior with unit tests

## Testing
- `pytest tests/unit/test_digest.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d077e7d0832bac74c3a073a01f16