### PR TITLE
feat: live CRM lookup with optional Redis cache

### DIFF
--- a/core/feature_flags.py
+++ b/core/feature_flags.py
@@ -8,6 +8,7 @@ ENABLE_PRO_SOURCES: bool = os.getenv("ENABLE_PRO_SOURCES", "0") == "1"
 ATTACH_PDF_TO_HUBSPOT: bool = os.getenv("ATTACH_PDF_TO_HUBSPOT", "1") == "1"
 ENABLE_SUMMARY: bool = os.getenv("ENABLE_SUMMARY", "0") == "1"
 ENABLE_GRAPH_STORAGE: bool = os.getenv("ENABLE_GRAPH_STORAGE", "0") == "1"
+ALLOW_STATIC_COMPANY_DATA: bool = os.getenv("ALLOW_STATIC_COMPANY_DATA", "0") == "1"
 
 __all__ = [
     "USE_PUSH_TRIGGERS",
@@ -15,4 +16,5 @@ __all__ = [
     "ATTACH_PDF_TO_HUBSPOT",
     "ENABLE_SUMMARY",
     "ENABLE_GRAPH_STORAGE",
+    "ALLOW_STATIC_COMPANY_DATA",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ requests
 # YAML parsing and testing
 pyyaml
 pytest
+redis
 
 jinja2>=3.1
 


### PR DESCRIPTION
## Summary
- search companies via HubSpot instead of static dataset
- add feature flag `ALLOW_STATIC_COMPANY_DATA` to enable test fallback
- extend fetch cache to optional Redis backend

## Testing
- `ruff check agents/internal_company/fetch.py core/feature_flags.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c717ae2768832b94ceab0616591b00