### PR TITLE
Raise PDF rendering errors in live mode

### DIFF
--- a/output/pdf_render.py
+++ b/output/pdf_render.py
@@ -34,6 +34,15 @@ except Exception:  # pragma: no cover - fallback when dependency missing
     Environment = FileSystemLoader = select_autoescape = None  # type: ignore
 
 
+def _ensure_weasyprint() -> None:
+    """Verify that the WeasyPrint dependency is installed."""
+
+    if HTML is None:
+        raise RuntimeError(
+            "WeasyPrint is required for PDF rendering. Install with 'pip install weasyprint'."
+        )
+
+
 def _html_from_data(data: Dict[str, Any]) -> str:
     """Return an HTML document representing ``data``.
 
@@ -122,6 +131,11 @@ def render_pdf(
         exports.
     """
 
+    live_mode = os.getenv("LIVE_MODE", "1") == "1"
+
+    if live_mode:
+        _ensure_weasyprint()
+
     # --- Legacy behaviour: render_pdf(data, out_path) -------------------
     if isinstance(out_path_or_fields, (str, Path)):
         out_path = Path(out_path_or_fields)
@@ -129,6 +143,8 @@ def render_pdf(
         try:
             _write_html_pdf(html, out_path)
         except Exception:
+            if live_mode:
+                raise
             out_path.write_text(html, encoding="utf-8")
         return
 
@@ -158,6 +174,8 @@ def render_pdf(
             _write_html_pdf(html, out_path)
             return
         except Exception:
+            if live_mode:
+                raise
             try:
                 _write_empty_pdf(out_path, reason)
                 return
@@ -170,6 +188,8 @@ def render_pdf(
     try:
         _write_html_pdf(html, out_path)
     except Exception:
+        if live_mode:
+            raise
         out_path.write_text(html, encoding="utf-8")
 
 

--- a/tests/integration/test_workflow_outputs.py
+++ b/tests/integration/test_workflow_outputs.py
@@ -14,6 +14,7 @@ def test_orchestrator_generates_outputs_and_calls_hubspot(tmp_path, monkeypatch,
     monkeypatch.setenv("USE_PUSH_TRIGGERS", "1")
     monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "token")
     monkeypatch.setenv("HUBSPOT_PORTAL_ID", "portal")
+    monkeypatch.setenv("LIVE_MODE", "0")
     # reload feature flags to pick up env change
     monkeypatch.setattr(feature_flags, "USE_PUSH_TRIGGERS", True)
 

--- a/tests/test_exports_safety.py
+++ b/tests/test_exports_safety.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from output import csv_export, pdf_render
@@ -18,9 +20,19 @@ def test_csv_with_header_on_empty(tmp_path):
     assert contents == [",".join(csv_export.DEFAULT_FIELDS)]
 
 
-def test_pdf_created_on_empty(tmp_path):
+def test_pdf_created_on_empty(tmp_path, monkeypatch):
     rows = []
-    os.chdir(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "0")
     pdf_render.render_pdf(rows, ["company_name"], {"reason": "no_triggers"})
     assert (tmp_path / "output/exports/report.pdf").exists()
+
+
+def test_pdf_raises_in_live_mode(tmp_path, monkeypatch):
+    rows = []
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "1")
+    monkeypatch.setattr(pdf_render, "HTML", None)
+    with pytest.raises(RuntimeError):
+        pdf_render.render_pdf(rows, ["company_name"], {"reason": "no_triggers"})
 


### PR DESCRIPTION
## Summary
- Let `_write_html_pdf` exceptions propagate during live operation and add `LIVE_MODE` gating to all PDF renders
- Introduce dependency check for WeasyPrint with clear installation message
- Extend tests to cover live-mode failures and adjust existing tests to run in offline mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71cd8ac80832b8d70ff469ab34d54