### PR TITLE
Raise error when Google API libraries missing in LIVE mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ flowchart LR
    ```bash
    pip install -r requirements.txt
    ```
-   Missing Google API libraries log a `google_api_client_missing` step for
-   Calendar and Contacts.
+   The Google Calendar and Contacts integrations require the
+   `google-api-python-client` and `google-auth` packages. Missing Google
+   API libraries log a `google_api_client_missing` step for Calendar and
+   Contacts.
 3. Set required environment variables as needed. SMTP/IMAP/HubSpot/Google variables are listed in [`.env.example`](.env.example) and documented in [`ops/CONFIG.md`](ops/CONFIG.md).
 4. Adjust trigger words in `config/trigger_words.txt` or point `TRIGGER_WORDS_FILE` to a custom list.
 

--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -96,6 +96,8 @@ def fetch_events() -> List[Normalized]:
     if not build or not Credentials:
         log_step("calendar", "google_api_client_missing", {}, severity="error")
         log_event({"status": "google_api_client_missing", "severity": "error"})
+        if os.getenv("LIVE_MODE", "1") == "1":
+            raise RuntimeError("google_api_client_missing")
         return results
     try:
         creds = build_user_credentials(SCOPES)

--- a/integrations/google_contacts.py
+++ b/integrations/google_contacts.py
@@ -79,6 +79,8 @@ def fetch_contacts(
         log_step("contacts", "google_api_client_missing", {}, severity="error")
         from core.orchestrator import log_event
         log_event({"status": "google_api_client_missing", "severity": "error"})
+        if os.getenv("LIVE_MODE", "1") == "1":
+            raise RuntimeError("google_api_client_missing")
         return []
 
     try:

--- a/tests/unit/test_google_calendar_error_logging.py
+++ b/tests/unit/test_google_calendar_error_logging.py
@@ -12,6 +12,7 @@ from core import orchestrator
 
 def test_fetch_events_logs_when_api_client_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "0")
     records = []
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
     monkeypatch.setattr(google_calendar, "build", None)
@@ -24,6 +25,7 @@ def test_fetch_events_logs_when_api_client_missing(tmp_path, monkeypatch):
 
 def test_fetch_events_logs_when_oauth_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "0")
     records = []
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
     monkeypatch.setattr(google_calendar, "build", object())
@@ -37,6 +39,7 @@ def test_fetch_events_logs_when_oauth_missing(tmp_path, monkeypatch):
 
 def test_gather_triggers_mirrors_calendar_error(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "0")
     records = []
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
     monkeypatch.setattr(orchestrator, "fetch_events", lambda: [])
@@ -51,3 +54,12 @@ def test_gather_triggers_mirrors_calendar_error(tmp_path, monkeypatch):
     triggers = orchestrator.gather_triggers()
     assert triggers == []
     assert any(r.get("status") == "fetch_error" and r.get("error") == "boom" for r in records)
+
+
+def test_fetch_events_raises_when_api_client_missing_live_mode(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "1")
+    monkeypatch.setattr(google_calendar, "build", None)
+    monkeypatch.setattr(google_calendar, "Credentials", None)
+    with pytest.raises(RuntimeError):
+        google_calendar.fetch_events()

--- a/tests/unit/test_google_contacts_error_logging.py
+++ b/tests/unit/test_google_contacts_error_logging.py
@@ -11,6 +11,7 @@ from core import orchestrator
 
 def test_fetch_contacts_logs_when_api_client_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "0")
     records = []
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
     monkeypatch.setattr(google_contacts, "build", None)
@@ -23,6 +24,7 @@ def test_fetch_contacts_logs_when_api_client_missing(tmp_path, monkeypatch):
 
 def test_gather_triggers_logs_no_contacts(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "0")
     records = []
     monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
     monkeypatch.setattr(orchestrator, "fetch_events", lambda: [])
@@ -33,3 +35,12 @@ def test_gather_triggers_logs_no_contacts(tmp_path, monkeypatch):
     triggers = orchestrator.gather_triggers()
     assert triggers == []
     assert any(r.get("status") == "no_contacts" for r in records)
+
+
+def test_fetch_contacts_raises_when_api_client_missing_live_mode(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "1")
+    monkeypatch.setattr(google_contacts, "build", None)
+    monkeypatch.setattr(google_contacts, "Request", None)
+    with pytest.raises(RuntimeError):
+        google_contacts.fetch_contacts()


### PR DESCRIPTION
## Summary
- raise RuntimeError in LIVE mode when Google Calendar/Contacts libraries are absent
- document google-api-python-client and google-auth requirements
- test that missing Google libraries raise in LIVE mode and log in non-live mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c71eb6d8b0832b835f51d73ce50b1f