### PR TITLE
Fail fast in live mode on contact fetch errors

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -407,6 +407,8 @@ def gather_triggers(
                         "error": str(e),
                     }
                 )
+                if os.getenv("LIVE_MODE", "1") == "1":
+                    raise
                 contacts = []
             con_code = _contacts_fetch_logged(wf_id)
             if con_code:
@@ -478,6 +480,8 @@ def run(
                         "error": str(e),
                     }
                 )
+                if os.getenv("LIVE_MODE", "1") == "1":
+                    raise
                 contacts = []
             for c in contacts:
                 cid = c.get("contact_id") or c.get("id") or c.get("resourceName")


### PR DESCRIPTION
## Summary
- raise the `fetch_contacts` error during trigger collection or run when `LIVE_MODE=1`
- test live-mode behavior for `gather_triggers` and `run`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c723e2c770832ba06772315cf90d62