### PR TITLE
Refactor orchestrator responsibilities into dedicated modules

### DIFF
--- a/core/exports.py
+++ b/core/exports.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Tuple
+
+
+def resolve_exporters(
+    pdf_renderer: Callable[[Dict[str, Any], Path], None] | None,
+    csv_exporter: Callable[[List[Dict[str, Any]], Path], None] | None,
+    *,
+    test_mode: bool,
+) -> Tuple[
+    Callable[[Dict[str, Any], Path], None],
+    Callable[[List[Dict[str, Any]], Path], None],
+    Callable[[Dict[str, Any], Path], None],
+    Callable[[List[Dict[str, Any]], Path], None],
+]:
+    from output import csv_export as csv_module
+    from output import pdf_render as pdf_module
+
+    fallback_pdf = pdf_module.render_pdf
+    fallback_csv = csv_module.export_csv
+
+    if not test_mode:
+        return fallback_pdf, fallback_csv, fallback_pdf, fallback_csv
+
+    return (
+        pdf_renderer or fallback_pdf,
+        csv_exporter or fallback_csv,
+        fallback_pdf,
+        fallback_csv,
+    )
+
+
+def create_idle_artifacts(
+    *,
+    log_event: Callable[[Dict[str, Any]], None],
+) -> Tuple[Path, Path]:
+    from output import csv_export
+    from output import pdf_render
+
+    outdir = Path(os.getenv("OUTPUT_DIR", "output")) / "exports"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    pdf_path = outdir / "report.pdf"
+    csv_path = outdir / "data.csv"
+
+    empty_report = {
+        "fields": ["info"],
+        "rows": [{"info": "No valid triggers in current window"}],
+        "meta": {"reason": "no_triggers"},
+    }
+
+    try:
+        pdf_render.render_pdf(empty_report, pdf_path)
+        log_event({"status": "artifact_pdf", "path": str(pdf_path)})
+    except Exception as exc:
+        log_event(
+            {
+                "status": "artifact_pdf_error",
+                "error": str(exc),
+                "severity": "warning",
+            }
+        )
+
+    try:
+        csv_export.export_csv([], csv_path)
+        log_event({"status": "artifact_csv", "path": str(csv_path)})
+    except Exception as exc:
+        log_event(
+            {
+                "status": "artifact_csv_error",
+                "error": str(exc),
+                "severity": "warning",
+            }
+        )
+
+    return pdf_path, csv_path
+
+
+def export_report(
+    consolidated: Dict[str, Any],
+    first_event_id: Any,
+    pdf_renderer: Callable[[Dict[str, Any], Path], None],
+    csv_exporter: Callable[[List[Dict[str, Any]], Path], None],
+    fallback_pdf: Callable[[Dict[str, Any], Path], None],
+    fallback_csv: Callable[[List[Dict[str, Any]], Path], None],
+    *,
+    log_event: Callable[[Dict[str, Any]], None],
+    log_step: Callable[[str, str, Dict[str, Any]], None],
+) -> Tuple[Path, Path]:
+    outdir = Path(os.getenv("OUTPUT_DIR", "output")) / "exports"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    pdf_path = outdir / "report.pdf"
+    csv_path = outdir / "data.csv"
+
+    pdf_renderer(consolidated, pdf_path)
+    csv_exporter(consolidated.get("rows", []), csv_path)
+
+    try:
+        if pdf_path.exists() and pdf_path.stat().st_size < 1000:
+            fallback_pdf(
+                {
+                    "fields": ["info"],
+                    "rows": [{"info": "invalid_artifact_detected"}],
+                    "meta": {},
+                },
+                pdf_path,
+            )
+        if csv_path.exists() and csv_path.stat().st_size < 5:
+            fallback_csv([], csv_path)
+    except Exception:
+        pass
+
+    log_event({"event_id": first_event_id, "status": "artifact_pdf", "path": str(pdf_path)})
+    log_event({"event_id": first_event_id, "status": "artifact_csv", "path": str(csv_path)})
+    log_step(
+        "orchestrator",
+        "report_generated",
+        {"event_id": first_event_id, "path": str(pdf_path)},
+    )
+
+    return pdf_path, csv_path
+
+
+__all__ = [
+    "resolve_exporters",
+    "create_idle_artifacts",
+    "export_report",
+]

--- a/core/hubspot_ops.py
+++ b/core/hubspot_ops.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+def check_existing_and_prompt(
+    *,
+    triggers: Optional[List[Dict[str, Any]]],
+    company_id: Any,
+    hubspot_check_existing: Callable[[Any], Any] | None,
+    email_sender: Any,
+    email_reader: Any,
+    log_event: Callable[[Dict[str, Any]], None],
+) -> Tuple[Any, bool]:
+    existing = hubspot_check_existing(company_id) if hubspot_check_existing else None
+    if not existing:
+        return existing, True
+
+    first_trigger = (triggers or [{}])[0]
+    payload = first_trigger.get("payload") or {}
+    first_event_id = payload.get("event_id")
+    creator = first_trigger.get("creator")
+
+    if creator:
+        try:
+            email_sender.send_email(
+                to=creator,
+                subject="Existing report found",
+                body=(
+                    "A report already exists for this company. "
+                    "Reply with Ja to continue or Nein to skip."
+                ),
+                task_id=first_event_id,
+            )
+        except Exception:
+            pass
+
+    log_event({"event_id": first_event_id, "status": "report_exists_query"})
+
+    decision = "yes"
+    try:
+        replies = email_reader.fetch_replies()
+    except Exception:
+        replies = []
+
+    for reply in replies:
+        if reply.get("creator") == creator:
+            text = str(reply.get("text") or "").strip().lower()
+            if text in {"nein", "no"}:
+                decision = "no"
+            elif text in {"ja", "yes"}:
+                decision = "yes"
+            break
+
+    if decision != "yes":
+        log_event({"event_id": first_event_id, "status": "report_skipped"})
+        return existing, False
+
+    return existing, True
+
+
+def upsert_and_attach(
+    *,
+    consolidated: Dict[str, Any],
+    company_id: Any,
+    pdf_path: Path,
+    hubspot_upsert: Callable[[Dict[str, Any]], Any] | None,
+    hubspot_attach: Callable[[Path, Any], None] | None,
+    feature_flags: Any,
+    log_event: Callable[[Dict[str, Any]], None],
+    log_step: Callable[[str, str, Dict[str, Any]], None],
+    recovery_agent: Any,
+    first_event_id: Any,
+) -> Tuple[Any, bool]:
+    new_company_id = company_id
+    if new_company_id is None and hubspot_upsert:
+        new_company_id = hubspot_upsert(consolidated)
+
+    if (
+        feature_flags.ATTACH_PDF_TO_HUBSPOT
+        and new_company_id
+        and pdf_path.exists()
+        and hubspot_attach
+    ):
+        try:
+            hubspot_attach(pdf_path, new_company_id)
+            log_event({"event_id": first_event_id, "status": "report_uploaded"})
+        except Exception as exc:
+            recovery_agent.handle_failure(first_event_id, exc)
+            log_event(
+                {
+                    "event_id": first_event_id,
+                    "status": "report_upload_failed",
+                    "severity": "critical",
+                }
+            )
+            log_step(
+                "orchestrator",
+                "report_error",
+                {"event_id": first_event_id, "error": str(exc)},
+                severity="critical",
+            )
+            log_step(
+                "orchestrator",
+                "report_upload_failed",
+                {"event_id": first_event_id},
+                severity="warning",
+            )
+            return new_company_id, False
+
+    return new_company_id, True
+
+
+__all__ = ["check_existing_and_prompt", "upsert_and_attach"]

--- a/core/run_loop.py
+++ b/core/run_loop.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+from core import statuses
+
+
+def incorporate_email_replies(
+    triggers: Optional[List[Dict[str, Any]]],
+    *,
+    email_listener: Any,
+    email_reader: Any,
+    log_event: Callable[[Dict[str, Any]], None],
+) -> List[Dict[str, Any]]:
+    triggers = triggers or []
+    replies: List[Dict[str, Any]] = []
+    if email_listener.has_pending_events():
+        try:
+            replies = email_reader.fetch_replies()
+        except Exception:
+            replies = []
+
+    for trigger in triggers:
+        payload = trigger.setdefault("payload", {})
+        task_id = (
+            payload.get("task_id")
+            or payload.get("id")
+            or payload.get("event_id")
+        )
+        for reply in list(replies):
+            try:
+                email_listener.run(json.dumps(reply))
+            except Exception:
+                pass
+            if reply.get("task_id") == task_id:
+                payload.update(reply.get("fields", {}))
+                event_id = payload.get("event_id") or reply.get("event_id")
+                log_event(
+                    {
+                        "status": "email_reply_received",
+                        "event_id": event_id,
+                        "creator": reply.get("creator"),
+                    }
+                )
+                log_event({"status": "pending_email_reply_resolved", "event_id": event_id})
+                log_event(
+                    {
+                        "status": "resumed",
+                        "event_id": event_id,
+                        "creator": reply.get("creator"),
+                    }
+                )
+                replies.remove(reply)
+
+    return triggers
+
+
+def filter_duplicate_triggers(
+    triggers: Optional[Iterable[Dict[str, Any]]],
+    *,
+    is_event_active: Callable[[str], bool],
+    log_event: Callable[[Dict[str, Any]], None],
+) -> List[Dict[str, Any]]:
+    filtered: List[Dict[str, Any]] = []
+    for trigger in triggers or []:
+        payload = trigger.get("payload", {})
+        event_id = payload.get("event_id")
+        if event_id and is_event_active(str(event_id)):
+            log_event({"event_id": event_id, "status": "duplicate_event"})
+            continue
+        filtered.append(trigger)
+    return filtered
+
+
+def resolve_researchers(
+    researchers: Optional[Sequence[Callable[[Dict[str, Any]], Dict[str, Any]]]] = None,
+) -> List[Callable[[Dict[str, Any]], Dict[str, Any]]]:
+    if researchers is not None:
+        return list(researchers)
+
+    from agents import (
+        agent_company_detail_research,
+        agent_external_level1_company_search,
+        agent_external_level2_companies_search,
+        agent_internal_level2_company_search,
+        agent_internal_search,
+    )
+
+    return [
+        agent_internal_search.run,
+        agent_external_level1_company_search.run,
+        agent_external_level2_companies_search.run,
+        agent_internal_level2_company_search.run,
+        agent_company_detail_research.run,
+    ]
+
+
+def run_researchers(
+    triggers: List[Dict[str, Any]],
+    researchers: Sequence[Callable[[Dict[str, Any]], Dict[str, Any]]],
+    *,
+    field_completion_agent: Any,
+    email_sender: Any,
+    log_event: Callable[[Dict[str, Any]], None],
+    missing_required: Callable[[str, Dict[str, Any]], List[str]],
+    extract_company: Callable[[Optional[str]], Optional[str]],
+    extract_domain: Callable[[Optional[str]], Optional[str]],
+    feature_flags: Any,
+) -> List[Dict[str, Any]]:
+    results: List[Dict[str, Any]] = []
+
+    for trigger in triggers:
+        payload = trigger.setdefault("payload", {})
+        event_id = payload.get("event_id")
+
+        if not payload.get("company_name"):
+            company = extract_company(payload.get("summary")) or extract_company(
+                payload.get("description")
+            )
+            if company:
+                payload["company_name"] = company
+        if not payload.get("domain"):
+            domain = extract_domain(payload.get("summary")) or extract_domain(
+                payload.get("description")
+            )
+            if domain:
+                payload["domain"] = domain
+
+        if event_id:
+            enriched = field_completion_agent.run(trigger) or {}
+            added_fields = {key: value for key, value in enriched.items() if not payload.get(key)}
+            if enriched:
+                payload.update(enriched)
+            missing = missing_required(trigger.get("source", ""), payload)
+            if missing:
+                log_event(
+                    {
+                        "event_id": event_id,
+                        "status": statuses.PENDING,
+                        "missing": missing,
+                    }
+                )
+                try:
+                    email_sender.send_email(
+                        to=trigger.get("creator"),
+                        subject="Missing information for research",
+                        body="Please reply with: " + ", ".join(missing),
+                        task_id=payload.get("task_id") or event_id,
+                    )
+                except Exception:
+                    pass
+                continue
+            elif added_fields:
+                log_event(
+                    {
+                        "event_id": event_id,
+                        "status": "enriched_by_ai",
+                        "fields": list(added_fields.keys()),
+                    }
+                )
+
+        if researchers:
+            log_event(
+                {
+                    "event_id": event_id,
+                    "status": statuses.PENDING,
+                    "creator": trigger.get("creator"),
+                }
+            )
+
+        trigger_results: List[Dict[str, Any]] = []
+        for researcher in researchers:
+            if getattr(researcher, "pro", False) and not feature_flags.ENABLE_PRO_SOURCES:
+                continue
+            result = researcher(trigger)
+            if result:
+                payload.update(result.get("payload", {}))
+                trigger_results.append(result)
+
+        if any(res.get("status") == "missing_fields" for res in trigger_results):
+            continue
+
+        results.extend(trigger_results)
+
+    return results
+
+
+def notify_reminders(
+    triggers: Sequence[Dict[str, Any]],
+    *,
+    reminder_service: Any,
+) -> None:
+    try:
+        reminder_service.check_and_notify(triggers)
+    except Exception:
+        pass
+
+
+def first_event_id(triggers: Sequence[Dict[str, Any]] | None) -> Any:
+    if not triggers:
+        return None
+    payload = (triggers[0].get("payload") or {}) if triggers else {}
+    return payload.get("event_id")
+
+
+__all__ = [
+    "incorporate_email_replies",
+    "filter_duplicate_triggers",
+    "resolve_researchers",
+    "run_researchers",
+    "notify_reminders",
+    "first_event_id",
+]

--- a/core/triggers.py
+++ b/core/triggers.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from core import statuses
+
+
+def _as_trigger_from_event(
+    event: Dict[str, Any],
+    *,
+    contains_trigger: Callable[[Dict[str, Any]], bool],
+) -> Optional[Dict[str, Any]]:
+    payload = event.get("payload") or event
+    if not contains_trigger(payload):
+        return None
+    return {
+        "source": "calendar",
+        "creator": (payload.get("creator") or {}).get("email")
+        or payload.get("creatorEmail"),
+        "recipient": (payload.get("organizer") or {}).get("email"),
+        "payload": payload,
+    }
+
+
+def _as_trigger_from_contact(contact: Dict[str, Any]) -> Dict[str, Any]:
+    email = ""
+    for item in contact.get("emailAddresses", []) or []:
+        value = (item or {}).get("value")
+        if value:
+            email = value
+            break
+    return {
+        "source": "contacts",
+        "creator": email,
+        "recipient": email,
+        "payload": contact,
+    }
+
+
+def gather_calendar_triggers(
+    events: Optional[List[Dict[str, Any]]] = None,
+    *,
+    fetch_events: Callable[[], List[Dict[str, Any]]] | None = None,
+    calendar_fetch_logged: Callable[[str], Optional[str]] | None = None,
+    calendar_last_error: Callable[[str], Optional[Dict[str, Any]]] | None = None,
+    get_workflow_id: Callable[[], str] | None = None,
+    log_event: Callable[[Dict[str, Any]], None] | None = None,
+    log_step: Callable[[str, str, Dict[str, Any]], None] | None = None,
+    contains_trigger: Callable[[Dict[str, Any]], bool] | None = None,
+) -> List[Dict[str, Any]]:
+    if log_event is None:
+        from core.logging import log_event as default_log_event
+
+        log_event = default_log_event
+    if log_step is None:
+        from core.utils import log_step as default_log_step
+
+        log_step = default_log_step
+    if contains_trigger is None:
+        from core.trigger_words import contains_trigger as default_contains_trigger
+
+        contains_trigger = default_contains_trigger
+    if get_workflow_id is None:
+        from core.utils import get_workflow_id as default_get_workflow_id
+
+        get_workflow_id = default_get_workflow_id
+    if fetch_events is None:
+        from integrations.google_calendar import fetch_events as default_fetch_events
+
+        fetch_events = default_fetch_events
+
+    workflow_id = get_workflow_id()
+
+    if events is None:
+        events = fetch_events() or []
+        if events == [] and calendar_last_error is not None:
+            err = calendar_last_error(workflow_id)
+            if err:
+                details = {
+                    key: value
+                    for key, value in err.items()
+                    if key
+                    not in {
+                        "workflow_id",
+                        "trigger_source",
+                        "status",
+                        "severity",
+                        "variant",
+                    }
+                }
+                log_event(
+                    {
+                        "status": err.get("status"),
+                        "severity": err.get("severity", "error"),
+                        **details,
+                    }
+                )
+
+    code = calendar_fetch_logged(workflow_id) if calendar_fetch_logged else None
+    if code:
+        log_event(
+            {
+                "status": f"calendar_fetch_{code}",
+                "severity": "warning",
+                "message": "Proceeding without calendar logs",
+            }
+        )
+
+    if not events or not any((event or {}).get("event_id") for event in events):
+        log_event({"status": "no_calendar_events", "severity": "warning"})
+        events = []
+
+    log_step("calendar", "fetch_return", {"count": len(events)})
+
+    triggers: List[Dict[str, Any]] = []
+    for event in events:
+        trigger = _as_trigger_from_event(event, contains_trigger=contains_trigger)
+        if trigger is None:
+            payload = event.get("payload") or event
+            event_id = payload.get("event_id") or payload.get("id")
+            log_step(
+                "calendar",
+                "event_discarded",
+                {
+                    "reason": "no_trigger_match",
+                    "event": {
+                        "id": event_id,
+                        "summary": payload.get("summary", ""),
+                    },
+                },
+            )
+            if event_id:
+                log_event({"event_id": event_id, "status": statuses.NOT_RELEVANT})
+            continue
+        triggers.append(trigger)
+    return triggers
+
+
+def gather_contact_triggers(
+    contacts: Optional[List[Dict[str, Any]]] = None,
+    *,
+    fetch_contacts: Callable[[], List[Dict[str, Any]]] | None = None,
+    contacts_fetch_logged: Callable[[str], Optional[str]] | None = None,
+    get_workflow_id: Callable[[], str] | None = None,
+    log_event: Callable[[Dict[str, Any]], None] | None = None,
+) -> List[Dict[str, Any]]:
+    if log_event is None:
+        from core.logging import log_event as default_log_event
+
+        log_event = default_log_event
+    if fetch_contacts is None:
+        from integrations.google_contacts import fetch_contacts as default_fetch_contacts
+
+        fetch_contacts = default_fetch_contacts
+    if get_workflow_id is None:
+        from core.utils import get_workflow_id as default_get_workflow_id
+
+        get_workflow_id = default_get_workflow_id
+
+    workflow_id = get_workflow_id()
+
+    if contacts is None:
+        try:
+            contacts = fetch_contacts() or []
+        except Exception as exc:
+            log_event(
+                {
+                    "status": "contacts_fetch_failed",
+                    "severity": "warning",
+                    "error": str(exc),
+                }
+            )
+            if os.getenv("LIVE_MODE", "1") == "1":
+                raise
+            contacts = []
+        code = contacts_fetch_logged(workflow_id) if contacts_fetch_logged else None
+        if code:
+            log_event(
+                {
+                    "status": f"contacts_fetch_{code}",
+                    "severity": "warning",
+                    "message": "Proceeding without contacts logs",
+                }
+            )
+
+    if not contacts:
+        log_event({"status": "no_contacts", "severity": "warning"})
+        return []
+
+    return [
+        trigger
+        for trigger in (_as_trigger_from_contact(contact) for contact in contacts)
+        if trigger
+    ]
+
+
+def gather_triggers(
+    events: Optional[List[Dict[str, Any]]] = None,
+    contacts: Optional[List[Dict[str, Any]]] = None,
+    *,
+    fetch_events: Callable[[], List[Dict[str, Any]]] | None = None,
+    fetch_contacts: Callable[[], List[Dict[str, Any]]] | None = None,
+    calendar_fetch_logged: Callable[[str], Optional[str]] | None = None,
+    contacts_fetch_logged: Callable[[str], Optional[str]] | None = None,
+    calendar_last_error: Callable[[str], Optional[Dict[str, Any]]] | None = None,
+    get_workflow_id: Callable[[], str] | None = None,
+    log_event: Callable[[Dict[str, Any]], None] | None = None,
+    log_step: Callable[[str, str, Dict[str, Any]], None] | None = None,
+    contains_trigger: Callable[[Dict[str, Any]], bool] | None = None,
+) -> List[Dict[str, Any]]:
+    if log_event is None:
+        from core.logging import log_event as default_log_event
+
+        log_event = default_log_event
+
+    try:
+        triggers: List[Dict[str, Any]] = []
+        triggers.extend(
+            gather_calendar_triggers(
+                events,
+                fetch_events=fetch_events,
+                calendar_fetch_logged=calendar_fetch_logged,
+                calendar_last_error=calendar_last_error,
+                get_workflow_id=get_workflow_id,
+                log_event=log_event,
+                log_step=log_step,
+                contains_trigger=contains_trigger,
+            )
+        )
+        triggers.extend(
+            gather_contact_triggers(
+                contacts,
+                fetch_contacts=fetch_contacts,
+                contacts_fetch_logged=contacts_fetch_logged,
+                get_workflow_id=get_workflow_id,
+                log_event=log_event,
+            )
+        )
+        return triggers
+    except Exception as exc:
+        log_event({"severity": "critical", "where": "gather_triggers", "error": str(exc)})
+        raise
+
+
+def _calendar_last_error(workflow_id: str) -> Optional[Dict[str, Any]]:
+    path = Path("logs") / "workflows" / "calendar.jsonl"
+    if not path.exists():
+        return None
+    last: Optional[Dict[str, Any]] = None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except Exception:
+                    continue
+                if record.get("workflow_id") == workflow_id and record.get("severity") == "error":
+                    last = record
+    except Exception:
+        return None
+    return last
+
+
+def _calendar_fetch_logged(workflow_id: str) -> Optional[str]:
+    path = Path("logs") / "workflows" / "calendar.jsonl"
+    if not path.exists():
+        return "missing"
+    required = {"fetch_ok"}
+    statuses_seen: set[str] = set()
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except Exception:
+                    continue
+                if record.get("workflow_id") == workflow_id:
+                    statuses_seen.add(record.get("status"))
+    except Exception:
+        return "missing"
+    if required.issubset(statuses_seen):
+        return None
+    if "google_api_client_missing" in statuses_seen:
+        return "missing_client"
+    if "missing_google_oauth_env" in statuses_seen or "fetch_error" in statuses_seen:
+        return "oauth_error"
+    return "missing"
+
+
+def _contacts_fetch_logged(workflow_id: str) -> Optional[str]:
+    path = Path("logs") / "workflows" / "contacts.jsonl"
+    if not path.exists():
+        return "missing"
+    statuses_seen: set[str] = set()
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except Exception:
+                    continue
+                if record.get("workflow_id") == workflow_id:
+                    statuses_seen.add(record.get("status"))
+    except Exception:
+        return "missing"
+    if "fetch_call" in statuses_seen:
+        return None
+    if "google_api_client_missing" in statuses_seen:
+        return "missing_client"
+    if "missing_google_oauth_env" in statuses_seen or "fetch_error" in statuses_seen:
+        return "oauth_error"
+    return "missing"
+
+
+__all__ = [
+    "gather_calendar_triggers",
+    "gather_contact_triggers",
+    "gather_triggers",
+    "_calendar_last_error",
+    "_calendar_fetch_logged",
+    "_contacts_fetch_logged",
+]


### PR DESCRIPTION
## Summary
- move trigger normalization utilities into `core/triggers.py` and expose thin wrappers from the orchestrator
- add a `core/run_loop.py` helper module so the orchestrator delegates email reply handling, researcher execution, and reminder dispatch
- create `core/exports.py` and `core/hubspot_ops.py` for export generation and HubSpot coordination, simplifying `run()`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c87053d98c832b9241ba74149d5d47