### PR TITLE
Add package marker __init__.py modules

### DIFF
--- a/a2a_logging/__init__.py
+++ b/a2a_logging/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for logging utilities."""

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for agent implementations."""

--- a/agents/internal_company/__init__.py
+++ b/agents/internal_company/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for internal company agent plugins."""

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for shared configuration."""

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for core workflow modules."""

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for integration adapters."""

--- a/output/__init__.py
+++ b/output/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for output generation utilities."""


### PR DESCRIPTION
## Summary
- add package marker `__init__.py` modules across agents, internal company, logging, core, config, integrations, and output directories so they are explicit Python packages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8933a0c8c832b80520658d14f764a