### PR TITLE
Normalize PDF renderer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ Key directories:
 - `agents/` – individual research agents.
 - `core/` – orchestration, classification, consolidation, and workflow helpers.
 - `integrations/` – external service clients (HubSpot, Google, email) and templates.
-- `output/` – PDF and CSV rendering utilities.
+- `output/` – PDF and CSV rendering utilities. The `pdf_render.render_pdf`
+  helper now accepts `(rows, fields, meta=None, out_path=None)` and returns the
+  written path; the legacy `(mapping, path)` signature is deprecated.
 - `schemas/` – JSON schema definitions.
 - `compliance/` – GDPR helpers.
 - `a2a_logging/` – logging utilities and error definitions.

--- a/core/full_workflow.py
+++ b/core/full_workflow.py
@@ -174,7 +174,14 @@ def run_full_workflow(
         csv_path = out_dir / "data.csv"
         # Write reports
         try:
-            pdf_render.render_pdf(consolidated, pdf_path)
+            meta = consolidated.get("meta")
+            meta_dict = dict(meta) if isinstance(meta, dict) else None
+            pdf_render.render_pdf(
+                list(consolidated.get("rows") or []),
+                list(consolidated.get("fields") or []),
+                meta_dict,
+                pdf_path,
+            )
         except Exception:
             pass
         try:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -242,7 +242,10 @@ def run(
     consolidate_fn: (
         Callable[[List[Dict[str, Any]]], Dict[str, Any]] | None
     ) = lambda r: {},
-    pdf_renderer: Callable[[Dict[str, Any], Path], None] | None = None,
+    pdf_renderer: (
+        Callable[[List[Dict[str, Any]], List[str], Dict[str, Any] | None, Path | None], Path]
+        | None
+    ) = None,
     csv_exporter: Callable[[List[Dict[str, Any]], Path], None] | None = None,
     hubspot_upsert: Callable[[Dict[str, Any]], Any] | None = lambda d: None,
     hubspot_attach: Callable[[Path, Any], None] | None = lambda p, c: None,

--- a/output/README.md
+++ b/output/README.md
@@ -15,4 +15,11 @@ Rendering utilities for PDF and CSV dossier generation.
 `weasyprint` for PDF rendering and the Python standard library for CSV.
 
 ## Usage
-Modules are called with consolidated data to produce deliverables.
+
+Use `render_pdf(rows, fields, meta=None, out_path=None)` to render a PDF report
+from table-style data. The function returns the :class:`pathlib.Path` of the
+written file and defaults to `SETTINGS.exports_dir / "report.pdf"` when
+`out_path` is omitted. Legacy code that previously called
+`render_pdf(mapping, path)` should migrate to the new signature. A temporary
+compatibility helper `render_pdf_from_mapping(mapping, path)` remains available
+and now emits a `DeprecationWarning` on use.

--- a/tests/test_exports_safety.py
+++ b/tests/test_exports_safety.py
@@ -37,3 +37,13 @@ def test_pdf_raises_in_live_mode(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError):
         pdf_render.render_pdf(rows, ["company_name"], {"reason": "no_triggers"})
 
+
+def test_legacy_wrapper_emits_warning(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LIVE_MODE", "0")
+    payload = {"rows": [], "fields": [], "meta": {"reason": "legacy"}}
+    out_path = SETTINGS.exports_dir / "legacy.pdf"
+    with pytest.deprecated_call():
+        pdf_render.render_pdf_from_mapping(payload, out_path)
+    assert out_path.exists()
+

--- a/tests/unit/test_as_trigger_from_event_fields.py
+++ b/tests/unit/test_as_trigger_from_event_fields.py
@@ -7,6 +7,13 @@ from core import orchestrator
 from config.settings import SETTINGS
 
 
+def _write_stub_pdf(out_path: Path | str | None) -> Path:
+    target = Path(out_path) if out_path else SETTINGS.exports_dir / "report.pdf"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("pdf")
+    return target
+
+
 def test_trigger_from_location_or_attendee():
     ev = {"summary": "Weekly sync", "description": "", "location": "Meeting Vorbereitung"}
     assert orchestrator._as_trigger_from_event(ev) is not None
@@ -39,7 +46,7 @@ def test_no_enriched_log_when_fields_present(monkeypatch, tmp_path):
         triggers=[trig],
         researchers=[],
         consolidate_fn=lambda r: {},
-        pdf_renderer=lambda data, path: path.write_text("pdf"),
+        pdf_renderer=lambda rows, fields, meta=None, out_path=None: _write_stub_pdf(out_path),
         csv_exporter=lambda data, path: path.write_text("csv"),
         hubspot_upsert=lambda d: None,
         hubspot_attach=lambda p, c: None,

--- a/tests/unit/test_orchestrator_exit.py
+++ b/tests/unit/test_orchestrator_exit.py
@@ -6,6 +6,13 @@ from agents import recovery_agent
 from config.settings import SETTINGS
 
 
+def _write_stub_pdf(out_path: Path | str | None) -> Path:
+    target = Path(out_path) if out_path else SETTINGS.exports_dir / "report.pdf"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("pdf")
+    return target
+
+
 def test_main_handles_string_exit(monkeypatch):
     def fake_run():
         raise SystemExit("No real calendar events detected – aborting run")
@@ -51,7 +58,7 @@ def test_run_logs_resumed_on_restart(tmp_path, monkeypatch):
     orchestrator.run(
         triggers=trig,
         researchers=[],
-        pdf_renderer=lambda d, p: None,
+        pdf_renderer=lambda rows, fields, meta=None, out_path=None: _write_stub_pdf(out_path),
         csv_exporter=lambda d, p: None,
         hubspot_upsert=lambda d: None,
         hubspot_attach=lambda p, c: None,

--- a/tests/unit/test_orchestrator_logging.py
+++ b/tests/unit/test_orchestrator_logging.py
@@ -10,6 +10,13 @@ from core import orchestrator, statuses
 from config.settings import SETTINGS
 
 
+def _write_stub_pdf(out_path: Path | str | None) -> Path:
+    target = Path(out_path) if out_path else SETTINGS.exports_dir / "report.pdf"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("pdf")
+    return target
+
+
 def test_gather_triggers_logs_discard_reasons(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     events = [
@@ -111,7 +118,7 @@ def test_run_invokes_recovery_on_failure(tmp_path, monkeypatch):
     orchestrator.run(
         triggers=trig,
         researchers=[],
-        pdf_renderer=lambda d, p: None,
+        pdf_renderer=lambda rows, fields, meta=None, out_path=None: _write_stub_pdf(out_path),
         csv_exporter=lambda d, p: None,
         hubspot_upsert=fail_hubspot,
         hubspot_attach=lambda p, c: None,


### PR DESCRIPTION
## Summary
- adopt a single `render_pdf(rows, fields, meta=None, out_path=None) -> Path` helper and add a deprecated mapping wrapper
- update exports, workflow orchestration, and tests to use the new signature and return value
- document the updated renderer contract and cover the legacy wrapper warning behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8984b9914832b8b346315287f19d9