### PR TITLE
Harden email allowlist enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ CRM.
 | `SMTP_PASS` | SMTP password | – |
 | `MAIL_FROM` | Sender e‑mail address (`SMTP_FROM` is deprecated; auto-aliases to `MAIL_FROM`) | `SMTP_USER` |
 | `SMTP_SECURE` | SMTP security mode (`ssl`/`starttls`) | `ssl` |
-| `ALLOWLIST_EMAIL_DOMAIN` | Allow reminder emails only to addresses in this domain | – |
+| `ALLOWLIST_EMAIL_DOMAIN` | Allow outbound emails only to addresses in this domain | – |
 | `MAIL_TO` | Recipient e‑mail for reports | – |
 | `TRIGGER_WORDS_FILE` | Path to trigger words list | `config/trigger_words.txt` |
 | `GOOGLE_CLIENT_ID_V2` | Google OAuth client ID | – |
@@ -225,6 +225,13 @@ CRM.
 | `STAGE` | Logging stage label | – |
 | `GITHUB_REPOSITORY` | Repository for error issues | – |
 | `GITHUB_TOKEN` | Token for GitHub issue creation | – |
+
+When `ALLOWLIST_EMAIL_DOMAIN` is configured the recipient address is validated in
+`integrations.email_sender` before a send attempt is made.  The normalized
+address and allowlisted domain are also forwarded to the low level
+`integrations.mailer` helper, which rejects any recipients outside the allowed
+domain.  This defence-in-depth setup ensures that even direct uses of the mailer
+cannot bypass the allowlist.
 
 ## Repository Structure
 

--- a/tests/unit/test_email_allowlist.py
+++ b/tests/unit/test_email_allowlist.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from integrations import email_sender, mailer
+
+
+def test_send_email_blocked_by_allowlist(monkeypatch):
+    monkeypatch.setenv("ALLOWLIST_EMAIL_DOMAIN", "example.com")
+
+    deliveries: list[tuple] = []
+    monkeypatch.setattr(email_sender, "_deliver", lambda *a, **k: deliveries.append((a, k)))
+
+    logs: list[tuple] = []
+    monkeypatch.setattr(email_sender, "log_step", lambda *a, **k: logs.append((a, k)))
+
+    email_sender.send_email("person@other.com", "subject", "body")
+
+    assert deliveries == []
+    assert any(args[1] == "email_skipped_invalid_domain" for args, _ in logs)
+
+
+def test_mailer_blocks_non_allowlisted_domain(monkeypatch):
+    called = False
+
+    class DummySMTP:
+        def __init__(self, *_, **__):
+            nonlocal called
+            called = True
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def login(self, *_):
+            raise AssertionError("login should not be called when blocked")
+
+        def sendmail(self, *_):
+            raise AssertionError("sendmail should not be called when blocked")
+
+    monkeypatch.setattr(mailer.smtplib, "SMTP_SSL", DummySMTP)
+
+    with pytest.raises(ValueError):
+        mailer.send_email(
+            host="smtp.example.com",
+            port=465,
+            user="user",
+            password="pass",
+            mail_from="sender@example.com",
+            to="recipient@unauthorised.com",
+            subject="Subject",
+            body="Body",
+            allowed_domain="example.com",
+        )
+
+    assert not called
+
+
+def test_mailer_allows_allowlisted_domain(monkeypatch):
+    sent: dict[str, object] = {}
+
+    class DummySMTP:
+        def __init__(self, *_, **__):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def login(self, user, password):
+            sent["login"] = (user, password)
+
+        def sendmail(self, mail_from, recipients, message):
+            sent["mail_from"] = mail_from
+            sent["recipients"] = recipients
+            sent["message"] = message
+
+    monkeypatch.setattr(mailer.smtplib, "SMTP_SSL", DummySMTP)
+    monkeypatch.setattr(mailer.ssl, "create_default_context", lambda: None)
+
+    mailer.send_email(
+        host="smtp.example.com",
+        port=465,
+        user="user",
+        password="pass",
+        mail_from="sender@example.com",
+        to=" Recipient@Example.com ",
+        subject="Subject",
+        body="Body",
+        allowed_domain="example.com",
+    )
+
+    assert sent["recipients"] == ["Recipient@Example.com"]
+    assert sent["mail_from"] == "sender@example.com"
+    assert "Subject" in sent["message"]


### PR DESCRIPTION
## Summary
- validate recipient domains in `integrations.email_sender`, reuse the sanitized address for delivery, and forward the configured allowlist to the SMTP helper
- guard `integrations.mailer.send_email` with an optional allowlisted domain and reject empty or out-of-scope recipients before dialing the server
- document the defence-in-depth behaviour and add unit tests that cover the new allowlist enforcement paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a7df86c4832bb2833d4614fdf8ff