### PR TITLE
Improve IMAP reply correlation and deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ The refresh token is bound to the exact client (ID/secret); mixing clients cause
 5. Consolidate data and generate PDF/CSV outputs.
 6. Optionally enrich HubSpot with core fields and attach the PDF.
 
+### Email Reply Processing
+
+Reminder e-mails include deterministic ``Message-ID`` headers derived from the
+task or event identifier.  `integrations.email_reader.fetch_replies()` stores
+the identifiers of processed messages and uses the ``In-Reply-To`` and
+``References`` headers to correlate replies back to their tasks.  Duplicate
+messages are skipped idempotently while activity is logged to
+``logs/workflows/replies.jsonl``.  The detailed flow is documented in
+[`docs/email_reply_processing.md`](docs/email_reply_processing.md).
+
 ## Data Model
 
 ### Two‑Layer Company Model

--- a/docs/email_reply_processing.md
+++ b/docs/email_reply_processing.md
@@ -1,0 +1,36 @@
+# Email Reply Processing
+
+The research workflow ingests replies from the shared IMAP mailbox and
+reconciles them with pending tasks.  Two components cooperate:
+
+1. **Outbound correlation metadata** – Every reminder or missing-fields
+   email sent through `integrations.email_sender` now generates a stable
+   ``Message-ID`` derived from the task or event identifier.  The
+   ``Message-ID`` and the associated identifiers are persisted in
+   ``logs/workflows/email_reader_state.json`` via
+   `integrations.email_reader.record_outbound_message()`.  This ensures
+   that replies referencing the original message can be matched purely via
+   the ``In-Reply-To`` or ``References`` headers.
+
+2. **Robust IMAP ingestion** – `integrations.email_reader.fetch_replies()`
+   loads the stored correlation map before polling IMAP.  Each unread
+   message is matched to the correct task using the header references.  If
+   headers are missing, the subject line is scanned for legacy ``Task`` or
+   ``Event`` patterns as a fallback.  Processed message identifiers are
+   stored in the same state file so the reader can resume after restarts
+   and skip duplicates.
+
+Additional diagnostics are appended to ``replies.jsonl`` for every
+message.  The log distinguishes between successfully processed replies,
+messages that did not contain structured data, and duplicates that were
+skipped because their ``Message-ID`` already exists in the processed
+state.
+
+The state file contains two keys:
+
+- ``processed_message_ids`` – sorted list of message identifiers that have
+  been processed (normalised without angle brackets).
+- ``correlation_index`` – mapping of normalised message identifiers to the
+  latest known ``task_id`` and ``event_id`` values.
+
+Developers can delete the state file during testing to reset the cache.

--- a/integrations/email_sender.py
+++ b/integrations/email_sender.py
@@ -9,14 +9,20 @@ the tests can assert against it.
 from __future__ import annotations
 
 from datetime import datetime
+from email.utils import make_msgid
 from typing import Optional, Sequence
+import logging as _py_logging
 import os
 import time
 from pathlib import Path
+import re
 
 from config.env import ensure_mail_from
 from .mailer import send_email as _send_email  # tatsächlicher SMTP/Provider-Client
 from core.utils import log_step
+from integrations import email_reader
+
+logger = _py_logging.getLogger(__name__)
 
 
 def _validate_recipient(to: str) -> str | None:
@@ -64,8 +70,36 @@ def _validate_recipient(to: str) -> str | None:
     return cleaned_to
 
 
+def _generate_message_id(identifier: Optional[str]) -> str | None:
+    if not identifier:
+        return None
+    token = re.sub(r"[^A-Za-z0-9.-]", "", identifier)
+    if not token:
+        return None
+    return make_msgid(idstring=f"task-{token}")
+
+
+def _record_outbound_correlation(
+    message_id: Optional[str], *, task_id: Optional[str], event_id: Optional[str]
+) -> None:
+    if not message_id:
+        return
+    try:
+        email_reader.record_outbound_message(
+            message_id, task_id=task_id, event_id=event_id
+        )
+    except Exception:
+        # Correlation is best-effort and must not interfere with sending.
+        logger.debug("Failed to record outbound message correlation", exc_info=True)
+
+
 def _deliver(
-    to: str, subject: str, body: str, attachments: Optional[Sequence[str]] = None
+    to: str,
+    subject: str,
+    body: str,
+    attachments: Optional[Sequence[str]] = None,
+    *,
+    message_id: Optional[str] = None,
 ) -> None:
     """Send message using environment configured SMTP credentials."""
     host = os.environ.get("SMTP_HOST")
@@ -96,6 +130,7 @@ def _deliver(
         secure=secure,
         attachments=list(attachments or []),
         allowed_domain=allowed_domain,
+        message_id=message_id,
     )
 
 
@@ -107,6 +142,7 @@ def send(
     sender: Optional[str] = None,
     attachments: Optional[Sequence[str]] = None,
     task_id: Optional[str] = None,
+    event_id: Optional[str] = None,
 ) -> None:
     """
     Generische Send-Funktion, die Tests monkeypatchen.
@@ -115,10 +151,15 @@ def send(
     if not validated_to:
         return
 
+    message_id = _generate_message_id(task_id)
+
     try:
-        _deliver(validated_to, subject, body, attachments)
+        _deliver(validated_to, subject, body, attachments, message_id=message_id)
         log_step(
             "orchestrator", "mail_sent", {"to": validated_to, "subject": subject}
+        )
+        _record_outbound_correlation(
+            message_id, task_id=task_id, event_id=event_id
         )
     except Exception as e:  # pragma: no cover - network errors
         log_step(
@@ -143,12 +184,14 @@ def send_email(
     sender: Optional[str] = None,
     attachments: Optional[Sequence[str]] = None,
     task_id: Optional[str] = None,
+    event_id: Optional[str] = None,
 ) -> None:
     """Wrapper around the low level mailer with logging and retries.
 
-    ``task_id`` may be supplied for correlation so that replies can be matched
-    to pending workflow items.  When provided it is logged with the message
-    metadata."""
+    ``task_id`` or ``event_id`` may be supplied for correlation so that
+    replies can be matched to pending workflow items.  When provided a
+    deterministic ``Message-ID`` is generated and persisted for the IMAP reply
+    processor."""
 
     validated_to = _validate_recipient(to)
     if not validated_to:
@@ -174,13 +217,24 @@ def send_email(
 
     delays = [5, 15, 45]
     last_exc: Exception | None = None
+    message_id = _generate_message_id(task_id)
+
     for attempt in range(3):
         try:
-            _deliver(validated_to, subject, body, attach_paths)
+            _deliver(
+                validated_to,
+                subject,
+                body,
+                attach_paths,
+                message_id=message_id,
+            )
             log_step(
                 "orchestrator",
                 "mail_sent",
                 {"to": validated_to, "subject": subject},
+            )
+            _record_outbound_correlation(
+                message_id, task_id=task_id, event_id=event_id
             )
             return
         except Exception as e:  # pragma: no cover - network errors
@@ -228,7 +282,12 @@ def request_missing_fields(task: dict, missing_fields: list[str], recipient_emai
         )
     )
 
-    send_email(to=recipient_email, subject=subject, body=body)
+    send_email(
+        to=recipient_email,
+        subject=subject,
+        body=body,
+        task_id=task.get("id"),
+    )
 
 
 def send_missing_fields_reminder(
@@ -262,7 +321,12 @@ def send_missing_fields_reminder(
     if allow and not recipient_email.lower().endswith(f"@{allow.lower()}"):
         log_step("mailer", "reminder_skipped_invalid_domain", {"to": recipient_email}, severity="warning")
         return
-    send_email(to=recipient_email, subject=subject, body=body)
+    send_email(
+        to=recipient_email,
+        subject=subject,
+        body=body,
+        task_id=task.get("id"),
+    )
 
 
 def send_reminder(
@@ -337,6 +401,7 @@ Thanks a lot for your support!
         subject=subject,
         body=body,
         task_id=task_id or event_id,
+        event_id=event_id,
     )
 
 

--- a/integrations/mailer.py
+++ b/integrations/mailer.py
@@ -24,6 +24,7 @@ def send_email(
     secure: str = "ssl",
     attachments: list[str] | None = None,
     allowed_domain: str | None = None,
+    message_id: str | None = None,
 ) -> None:
     """Send an e-mail via SMTP using the selected security mode.
 
@@ -53,6 +54,8 @@ def send_email(
     msg["From"] = mail_from
     msg["To"] = recipient
     msg["Subject"] = subject
+    if message_id:
+        msg["Message-ID"] = message_id
 
     for path in attachments or []:
         p = Path(path)

--- a/tests/unit/test_email_client.py
+++ b/tests/unit/test_email_client.py
@@ -14,7 +14,16 @@ import config.env as env_module
 def test_email_client_delegates_to_email_sender(monkeypatch):
     calls = {}
 
-    def fake_send(*, to, subject, body, sender=None, attachments=None, task_id=None):
+    def fake_send(
+        *,
+        to,
+        subject,
+        body,
+        sender=None,
+        attachments=None,
+        task_id=None,
+        event_id=None,
+    ):
         calls['sender'] = sender
         calls['recipient'] = to
         calls['subject'] = subject

--- a/tests/unit/test_email_reader_processing.py
+++ b/tests/unit/test_email_reader_processing.py
@@ -1,0 +1,90 @@
+import json
+from email.message import EmailMessage
+
+from integrations import email_reader
+
+
+class _FakeIMAP:
+    def __init__(self, raw_message: bytes, store_calls: list[tuple[bytes, str]]):
+        self._raw = raw_message
+        self._store_calls = store_calls
+
+    def login(self, user: str, pwd: str) -> None:
+        assert user == "user"
+        assert pwd == "pass"
+
+    def select(self, folder: str) -> None:
+        assert folder == "INBOX"
+
+    def search(self, charset, criteria):
+        return "OK", [b"1"]
+
+    def fetch(self, uid, query):
+        return "OK", [(b"1 (RFC822 {len})", self._raw)]
+
+    def store(self, uid, flags, value):
+        self._store_calls.append((uid, value))
+
+    def logout(self) -> None:
+        pass
+
+
+def test_fetch_replies_uses_headers_and_deduplicates(tmp_path, monkeypatch):
+    monkeypatch.setenv("IMAP_HOST", "imap.example.com")
+    monkeypatch.setenv("IMAP_PORT", "993")
+    monkeypatch.setenv("IMAP_USER", "user")
+    monkeypatch.setenv("IMAP_PASS", "pass")
+
+    monkeypatch.setattr(email_reader.SETTINGS, "workflows_dir", tmp_path)
+
+    task_id = "123e4567-e89b-12d3-a456-426655440000"
+    event_id = "2024-05-01_0900"
+    outbound_id = f"<task-{task_id}@example.com>"
+    email_reader.record_outbound_message(outbound_id, task_id=task_id, event_id=event_id)
+
+    msg = EmailMessage()
+    msg["Subject"] = 'Re: [Research Agent] Missing Information – "Quarterly Review"'
+    msg["From"] = "colleague@example.com"
+    msg["Message-ID"] = "<reply-1@example.com>"
+    msg["In-Reply-To"] = outbound_id
+    msg["References"] = outbound_id
+    msg.set_content(
+        "Company: Example GmbH\n"
+        "Domain: example.com\n"
+        "+49 12345678\n"
+        "contact@example.com\n"
+    )
+
+    raw_bytes = msg.as_bytes()
+    store_calls: list[tuple[bytes, str]] = []
+
+    def _fake_imap_factory(host, port):
+        assert host == "imap.example.com"
+        assert port == 993
+        return _FakeIMAP(raw_bytes, store_calls)
+
+    monkeypatch.setattr(email_reader.imaplib, "IMAP4_SSL", _fake_imap_factory)
+
+    first = email_reader.fetch_replies()
+    assert len(first) == 1
+    assert first[0]["task_id"] == task_id
+    assert first[0]["fields"]["domain"] == "example.com"
+
+    second = email_reader.fetch_replies()
+    assert second == []
+
+    assert len(store_calls) == 2
+
+    state_path = tmp_path / "email_reader_state.json"
+    assert state_path.exists()
+    state = json.loads(state_path.read_text())
+    assert "reply-1@example.com" in state["processed_message_ids"]
+
+    outbound_key = outbound_id.strip("<>").lower()
+    assert outbound_key in state["correlation_index"]
+    assert state["correlation_index"][outbound_key]["task_id"] == task_id
+
+    log_path = tmp_path / "replies.jsonl"
+    contents = log_path.read_text().splitlines()
+    assert any('"status": "reply_received"' in line for line in contents)
+    assert any('"status": "reply_duplicate_skipped"' in line for line in contents)

--- a/tests/unit/test_email_sender_reminder.py
+++ b/tests/unit/test_email_sender_reminder.py
@@ -10,7 +10,16 @@ from integrations import email_sender
 def test_send_reminder_formats_subject_and_body(monkeypatch):
     captured = {}
 
-    def fake_send(*, to, subject, body, sender=None, attachments=None, task_id=None):
+    def fake_send(
+        *,
+        to,
+        subject,
+        body,
+        sender=None,
+        attachments=None,
+        task_id=None,
+        event_id=None,
+    ):
         captured['subject'] = subject
         captured['body'] = body
 


### PR DESCRIPTION
## Summary
- persist processed message IDs and header correlation metadata in the IMAP reader so replies are matched via In-Reply-To/References with subject parsing as a fallback
- emit deterministic Message-ID values for outbound reminders, normalise logging imports, and capture correlation details in the shared state
- document the reply processing flow and cover it with unit tests for header matching, deduplication, and email sender behaviour

## Testing
- pytest tests/unit/test_email_reader_processing.py tests/unit/test_email_sender_reminder.py tests/unit/test_email_client.py

------
https://chatgpt.com/codex/tasks/task_e_68c8ac8af7b4832b8f6d76e55ee7adf5