### PR TITLE
Use structured log_step telemetry in integrations

### DIFF
--- a/docs/email_reply_processing.md
+++ b/docs/email_reply_processing.md
@@ -20,11 +20,13 @@ reconciles them with pending tasks.  Two components cooperate:
    stored in the same state file so the reader can resume after restarts
    and skip duplicates.
 
-Additional diagnostics are appended to ``replies.jsonl`` for every
-message.  The log distinguishes between successfully processed replies,
-messages that did not contain structured data, and duplicates that were
-skipped because their ``Message-ID`` already exists in the processed
-state.
+Additional diagnostics are emitted through ``core.utils.log_step`` using the
+``email_reader`` source for every message.  The structured log stream
+distinguishes between successfully processed replies, messages without
+structured data and duplicates that were skipped because their
+``Message-ID`` already exists in the processed state.  The shared telemetry
+format makes reply processing events available alongside calendar and contacts
+fetches.
 
 The state file contains two keys:
 

--- a/integrations/email_client.py
+++ b/integrations/email_client.py
@@ -10,6 +10,7 @@ from typing import Iterable, Optional
 import os
 
 from config.env import ensure_mail_from
+from core.utils import log_step
 
 from . import email_sender
 
@@ -35,6 +36,16 @@ def send_email(
     # Normalize and sort for deterministic output
     fields_list = sorted({f.strip() for f in missing_fields if f and f.strip()})
     has_fields = len(fields_list) > 0
+
+    log_step(
+        "email_client",
+        "compose_missing_fields_email",
+        {
+            "recipient": employee_email,
+            "missing_fields": fields_list,
+            "has_fields": has_fields,
+        },
+    )
 
     subject = "Missing information for research"
     # Friendlier copy with bullets when available

--- a/tests/unit/test_email_reader_processing.py
+++ b/tests/unit/test_email_reader_processing.py
@@ -84,7 +84,7 @@ def test_fetch_replies_uses_headers_and_deduplicates(tmp_path, monkeypatch):
     assert outbound_key in state["correlation_index"]
     assert state["correlation_index"][outbound_key]["task_id"] == task_id
 
-    log_path = tmp_path / "replies.jsonl"
+    log_path = tmp_path / "email_reader.jsonl"
     contents = log_path.read_text().splitlines()
     assert any('"status": "reply_received"' in line for line in contents)
     assert any('"status": "reply_duplicate_skipped"' in line for line in contents)

--- a/tests/unit/test_google_calendar_error_logging.py
+++ b/tests/unit/test_google_calendar_error_logging.py
@@ -14,27 +14,49 @@ def test_fetch_events_logs_when_api_client_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LIVE_MODE", "0")
     records = []
-    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+
+    def capture(source, stage, details, *, severity="info"):
+        records.append(
+            {
+                "source": source,
+                "stage": stage,
+                "details": details,
+                "severity": severity,
+            }
+        )
+
+    monkeypatch.setattr(google_calendar, "log_step", capture)
     monkeypatch.setattr(google_calendar, "build", None)
     monkeypatch.setattr(google_calendar, "Credentials", None)
 
     events = google_calendar.fetch_events()
     assert events == []
-    assert any(r.get("status") == "google_api_client_missing" for r in records)
+    assert any(r["stage"] == "google_api_client_missing" for r in records)
 
 
 def test_fetch_events_logs_when_oauth_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LIVE_MODE", "0")
     records = []
-    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+
+    def capture(source, stage, details, *, severity="info"):
+        records.append(
+            {
+                "source": source,
+                "stage": stage,
+                "details": details,
+                "severity": severity,
+            }
+        )
+
+    monkeypatch.setattr(google_calendar, "log_step", capture)
     monkeypatch.setattr(google_calendar, "build", object())
     monkeypatch.setattr(google_calendar, "Credentials", object)
     monkeypatch.setattr(google_calendar, "build_user_credentials", lambda scopes: None)
 
     events = google_calendar.fetch_events()
     assert events == []
-    assert any(r.get("status") == "missing_google_oauth_env" for r in records)
+    assert any(r["stage"] == "missing_google_oauth_env" for r in records)
 
 
 def test_gather_triggers_mirrors_calendar_error(tmp_path, monkeypatch):

--- a/tests/unit/test_google_contacts_error_logging.py
+++ b/tests/unit/test_google_contacts_error_logging.py
@@ -13,13 +13,24 @@ def test_fetch_contacts_logs_when_api_client_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LIVE_MODE", "0")
     records = []
-    monkeypatch.setattr(orchestrator, "log_event", lambda r: records.append(r))
+
+    def capture(source, stage, details, *, severity="info"):
+        records.append(
+            {
+                "source": source,
+                "stage": stage,
+                "details": details,
+                "severity": severity,
+            }
+        )
+
+    monkeypatch.setattr(google_contacts, "log_step", capture)
     monkeypatch.setattr(google_contacts, "build", None)
     monkeypatch.setattr(google_contacts, "Request", None)
 
     contacts = google_contacts.fetch_contacts()
     assert contacts == []
-    assert any(r.get("status") == "google_api_client_missing" for r in records)
+    assert any(r["stage"] == "google_api_client_missing" for r in records)
 
 
 def test_gather_triggers_logs_no_contacts(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- replace integration logging and diagnostics with `core.utils.log_step`, covering calendar, contacts, email, HubSpot, and scraper modules
- update associated tests and documentation to reflect the structured logging flow
- normalise email reply processing to emit telemetry through the shared log stream

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8b69f3144832b848a787f4e655356