### PR TITLE
Switch Google OAuth env vars to primary names

### DIFF
--- a/.github/workflows/a2a.yml
+++ b/.github/workflows/a2a.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Run orchestrator (LIVE)
         env:
           # Google OAuth
-          GOOGLE_CLIENT_ID_V2:     ${{ secrets.GOOGLE_CLIENT_ID_V2 }}
-          GOOGLE_CLIENT_SECRET_V2: ${{ secrets.GOOGLE_CLIENT_SECRET_V2 }}
+          GOOGLE_CLIENT_ID:        ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET:    ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_REFRESH_TOKEN:    ${{ secrets.GOOGLE_REFRESH_TOKEN }}
           GOOGLE_TOKEN_URI:        ${{ secrets.GOOGLE_TOKEN_URI != '' && secrets.GOOGLE_TOKEN_URI || 'https://oauth2.googleapis.com/token' }}
           # Kalender

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ sources.
    docker compose -f ops/docker-compose.yml up
    ```
 3. For scheduled runs via GitHub Actions, define repository secrets:
-   - `GOOGLE_CLIENT_ID_V2`
-   - `GOOGLE_CLIENT_SECRET_V2`
+   - `GOOGLE_CLIENT_ID`
+   - `GOOGLE_CLIENT_SECRET`
    - `GOOGLE_REFRESH_TOKEN`
    - `HUBSPOT_ACCESS_TOKEN`
    - `SMTP_HOST`
@@ -95,9 +95,9 @@ PDF generation relies on WeasyPrint system libraries, installed by the Dockerfil
 
 ## Google OAuth & Token Rotation
 
-> **Note:** <span style="color:red">v2-only</span> – legacy Google OAuth environment names (previous client ID/secret or JSON variants) will fail at startup.
+> **Note:** <span style="color:red">v2-only</span> – legacy Google OAuth environment names (e.g. the deprecated `_V2` or JSON variants) will fail at startup.
 
-The refresh token is bound to the exact client (ID/secret); mixing clients causes `invalid_grant` errors. To re-issue a refresh token, generate a consent URL with `access_type=offline` and `prompt=consent`. Only the v2 client (`GOOGLE_CLIENT_ID_V2`/`GOOGLE_CLIENT_SECRET_V2`) is supported.
+The refresh token is bound to the exact client (ID/secret); mixing clients causes `invalid_grant` errors. To re-issue a refresh token, generate a consent URL with `access_type=offline` and `prompt=consent`. Only the Google OAuth client configured via `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` is supported.
 
 ## LIVE mode
 
@@ -233,8 +233,8 @@ CRM.
 | `ALLOWLIST_EMAIL_DOMAIN` | Allow outbound emails only to addresses in this domain | – |
 | `MAIL_TO` | Recipient e‑mail for reports | – |
 | `TRIGGER_WORDS_FILE` | Path to trigger words list | `config/trigger_words.txt` |
-| `GOOGLE_CLIENT_ID_V2` | Google OAuth client ID | – |
-| `GOOGLE_CLIENT_SECRET_V2` | Google OAuth client secret | – |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID | – |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | – |
 | `GOOGLE_REFRESH_TOKEN` | Google OAuth refresh token | – |
 | `GOOGLE_CALENDAR_IDS` | Comma-separated calendar IDs to poll | `primary` |
 | `CAL_LOOKAHEAD_DAYS` | Days ahead to fetch events | `14` |

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -50,8 +50,8 @@ def _assert_live_ready() -> None:
     ensure_mail_from()
     # v2-only
     legacy = [
-        "GOOGLE_" + "CLIENT_ID",
-        "GOOGLE_" + "CLIENT_SECRET",
+        "GOOGLE_CLIENT_ID" + "_V2",
+        "GOOGLE_CLIENT_SECRET" + "_V2",
         "GOOGLE_" + "0",
         "GOOGLE_" + "OAUTH_JSON",
         "GOOGLE_" + "CREDENTIALS_JSON",
@@ -62,8 +62,8 @@ def _assert_live_ready() -> None:
         )
     required = [
         "GOOGLE_REFRESH_TOKEN",
-        "GOOGLE_CLIENT_ID_V2",
-        "GOOGLE_CLIENT_SECRET_V2",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
         "SMTP_HOST",
         "SMTP_PORT",
         "SMTP_USER",

--- a/desktop/a2a-oauth/get_refresh_token.py
+++ b/desktop/a2a-oauth/get_refresh_token.py
@@ -3,7 +3,7 @@
 The legacy "out of band" (OOB) redirect has been deprecated by Google. This
 script now follows the recommended loopback redirect approach:
 
-1. Ensure ``GOOGLE_CLIENT_ID_V2`` and ``GOOGLE_CLIENT_SECRET_V2`` are defined
+1. Ensure ``GOOGLE_CLIENT_ID`` and ``GOOGLE_CLIENT_SECRET`` are defined
    in your environment (``.env``).
 2. Run the script. It spins up a temporary HTTP server on ``localhost:8888``
    and prints the consent URL.
@@ -128,11 +128,11 @@ def exchange_code_for_tokens(client_id: str, client_secret: str, code: str) -> d
 def main() -> None:
     load_dotenv()
 
-    client_id = os.getenv("GOOGLE_CLIENT_ID_V2")
-    client_secret = os.getenv("GOOGLE_CLIENT_SECRET_V2")
+    client_id = os.getenv("GOOGLE_CLIENT_ID")
+    client_secret = os.getenv("GOOGLE_CLIENT_SECRET")
     if not client_id or not client_secret:
         raise SystemExit(
-            "GOOGLE_CLIENT_ID_V2 and GOOGLE_CLIENT_SECRET_V2 must be set in the environment/.env file."
+            "GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set in the environment/.env file."
         )
 
     server_thread = start_callback_server()

--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -125,7 +125,7 @@ def fetch_events() -> List[Normalized]:
             service.calendarList().get(calendarId=CAL_IDS[0]).execute()
         except Exception as e:
             code, hint = classify_oauth_error(e)
-            cid_tail = (os.getenv("GOOGLE_CLIENT_ID_V2") or "")[-8:]
+            cid_tail = (os.getenv("GOOGLE_CLIENT_ID") or "")[-8:]
             log_step(
                 "calendar",
                 "fetch_error",
@@ -173,7 +173,7 @@ def fetch_events() -> List[Normalized]:
         log_step("calendar", "fetch_ok", {"calendars": CAL_IDS, "count": len(results)})
     except Exception as e:  # pragma: no cover
         code, hint = classify_oauth_error(e)
-        cid_tail = (os.getenv("GOOGLE_CLIENT_ID_V2") or "")[-8:]
+        cid_tail = (os.getenv("GOOGLE_CLIENT_ID") or "")[-8:]
         log_step(
             "calendar",
             "fetch_error",

--- a/integrations/google_contacts.py
+++ b/integrations/google_contacts.py
@@ -147,7 +147,7 @@ def fetch_contacts(
         return out
     except Exception as e:
         code, hint = classify_oauth_error(e)
-        cid_tail = (os.getenv("GOOGLE_CLIENT_ID_V2") or "")[-8:]
+        cid_tail = (os.getenv("GOOGLE_CLIENT_ID") or "")[-8:]
         log_step(
             "contacts",
             "fetch_error",

--- a/integrations/google_oauth.py
+++ b/integrations/google_oauth.py
@@ -1,4 +1,4 @@
-"""Google OAuth (v2-only): requires GOOGLE_CLIENT_ID_V2 / GOOGLE_CLIENT_SECRET_V2 / GOOGLE_REFRESH_TOKEN."""
+"""Google OAuth: requires GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET / GOOGLE_REFRESH_TOKEN."""
 from __future__ import annotations
 
 import os
@@ -24,23 +24,23 @@ class OAuthError(Exception):
 def build_user_credentials(scopes: List[str]) -> Optional["Credentials"]:
     if Credentials is None:
         return None
-    client_id = os.getenv("GOOGLE_CLIENT_ID_V2")
-    client_secret = os.getenv("GOOGLE_CLIENT_SECRET_V2")
+    client_id = os.getenv("GOOGLE_CLIENT_ID")
+    client_secret = os.getenv("GOOGLE_CLIENT_SECRET")
     refresh_token = os.getenv("GOOGLE_REFRESH_TOKEN")
     token_uri = os.getenv("GOOGLE_TOKEN_URI", DEFAULT_TOKEN_URI)
     if not (client_id and client_secret and refresh_token):
         return None
     # Hard block if legacy vars are present to avoid accidental mixing.
     legacy = [
-        "GOOGLE_" + "CLIENT_ID",
-        "GOOGLE_" + "CLIENT_SECRET",
+        "GOOGLE_CLIENT_ID" + "_V2",
+        "GOOGLE_CLIENT_SECRET" + "_V2",
         "GOOGLE_" + "0",
         "GOOGLE_" + "OAUTH_JSON",
         "GOOGLE_" + "CREDENTIALS_JSON",
     ]
     if any(os.getenv(k) for k in legacy):
         raise RuntimeError(
-            "Legacy Google OAuth variables detected; v2-only is enforced. Remove legacy envs."
+            "Legacy Google OAuth variables detected; use GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET instead."
         )
     return Credentials(
         token=None,
@@ -55,11 +55,11 @@ def classify_oauth_error(err: Exception) -> Tuple[str, str]:
     msg = str(err).lower()
     if "invalid_grant" in msg:
         return ("invalid_grant",
-                "Refresh token expired/revoked or not issued for this v2 client. "
-                "Ensure Consent Screen is IN PRODUCTION and re-issue with the same v2 client "
+                "Refresh token expired/revoked or not issued for this client. "
+                "Ensure Consent Screen is IN PRODUCTION and re-issue with the same client "
                 "(access_type=offline, prompt=consent).")
     if "invalid_client" in msg:
-        return ("invalid_client", "Check GOOGLE_CLIENT_ID_V2 / GOOGLE_CLIENT_SECRET_V2 values.")
+        return ("invalid_client", "Check GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET values.")
     if "unauthorized_client" in msg:
         return ("unauthorized_client", "Client not allowed for scopes; verify Cloud Console settings.")
     if "invalid_scope" in msg:

--- a/ops/CONFIG.md
+++ b/ops/CONFIG.md
@@ -3,12 +3,12 @@
 Document environment variables and secrets required for the workflow.
 See repository README for common variables.
 
-> **Note:** <span style="color:red">v2-only</span> – legacy Google OAuth environment names (previous client ID/secret or JSON variants) will fail at startup.
+> **Note:** <span style="color:red">v2-only</span> – legacy Google OAuth environment names (e.g. deprecated `_V2` or JSON variants) will fail at startup.
 
 ## Secrets
 - `HUBSPOT_ACCESS_TOKEN`
-- `GOOGLE_CLIENT_ID_V2`
-- `GOOGLE_CLIENT_SECRET_V2`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
 - `GOOGLE_REFRESH_TOKEN`
 - Optional: `GOOGLE_TOKEN_URI` (Default: https://oauth2.googleapis.com/token)
 - `SMTP_HOST` (optional)

--- a/ops/no_legacy_oauth_guard.py
+++ b/ops/no_legacy_oauth_guard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys, re
 from pathlib import Path
-rx = re.compile(r"GOOGLE_CLIENT_(ID|SECRET)(?!_V2)\b|GOOGLE_(0|OAUTH_JSON|CREDENTIALS_JSON)\b")
+rx = re.compile(r"GOOGLE_CLIENT_(?:ID|SECRET)_V2\b|GOOGLE_(0|OAUTH_JSON|CREDENTIALS_JSON)\b")
 bad = []
 for p in Path('.').rglob('*'):
     if p.is_file() and p.suffix in {'.py','.md','.yaml','.yml','.env','.ini','.json','.j2','.txt','.html'}:

--- a/tests/test_google_oauth_env_mapping.py
+++ b/tests/test_google_oauth_env_mapping.py
@@ -3,18 +3,18 @@ from integrations.google_oauth import build_user_credentials
 
 SCOPES = ["x"]
 
-def test_v2_envs_work(monkeypatch):
-    for k in ["GOOGLE_CLIENT_ID_V2","GOOGLE_CLIENT_SECRET_V2","GOOGLE_REFRESH_TOKEN"]: monkeypatch.delenv(k, raising=False)
-    monkeypatch.setenv("GOOGLE_CLIENT_ID_V2","id")
-    monkeypatch.setenv("GOOGLE_CLIENT_SECRET_V2","sec")
+def test_primary_envs_work(monkeypatch):
+    for k in ["GOOGLE_CLIENT_ID","GOOGLE_CLIENT_SECRET","GOOGLE_REFRESH_TOKEN"]: monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("GOOGLE_CLIENT_ID","id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET","sec")
     monkeypatch.setenv("GOOGLE_REFRESH_TOKEN","rt")
     assert build_user_credentials(SCOPES) is not None
 
 def test_legacy_envs_cause_error(monkeypatch):
-    monkeypatch.setenv("GOOGLE_CLIENT_ID_V2","id")
-    monkeypatch.setenv("GOOGLE_CLIENT_SECRET_V2","sec")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID","id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET","sec")
     monkeypatch.setenv("GOOGLE_REFRESH_TOKEN","rt")
-    legacy_key = "GOOGLE_" + "CLIENT_ID"
+    legacy_key = "GOOGLE_CLIENT_ID" + "_V2"
     monkeypatch.setenv(legacy_key, "legacy")
     with pytest.raises(RuntimeError):
         build_user_credentials(SCOPES)

--- a/tests/test_live_enforcement.py
+++ b/tests/test_live_enforcement.py
@@ -9,8 +9,8 @@ import core.orchestrator as orch
 def test_live_guard_fails_without_env(monkeypatch):
     monkeypatch.setenv("LIVE_MODE","1")
     for k in [
-        "GOOGLE_CLIENT_ID_V2",
-        "GOOGLE_CLIENT_SECRET_V2",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
         "GOOGLE_REFRESH_TOKEN",
         "SMTP_HOST",
         "SMTP_PORT",
@@ -26,8 +26,8 @@ def test_live_guard_fails_without_env(monkeypatch):
 
 def test_live_guard_accepts_legacy_smtp_from(monkeypatch, caplog):
     monkeypatch.setenv("LIVE_MODE", "1")
-    monkeypatch.setenv("GOOGLE_CLIENT_ID_V2", "client")
-    monkeypatch.setenv("GOOGLE_CLIENT_SECRET_V2", "secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "client")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "secret")
     monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "refresh")
     monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
     monkeypatch.setenv("SMTP_PORT", "587")


### PR DESCRIPTION
## Summary
- update the legacy OAuth guard to flag the deprecated GOOGLE_CLIENT_*_V2 identifiers
- switch the orchestrator, Google OAuth helpers, and automation workflow to use the primary GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET variables
- refresh documentation and tests to validate the new env var mapping and keep legacy `_V2` names blocked

## Testing
- python ops/no_legacy_oauth_guard.py
- pytest tests/test_live_enforcement.py tests/test_google_oauth_env_mapping.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d2549c38832ba562d6bbf15134eb