### PR TITLE
Log calendar trigger detections

### DIFF
--- a/core/triggers.py
+++ b/core/triggers.py
@@ -145,10 +145,10 @@ def gather_calendar_triggers(
 
     triggers: List[Dict[str, Any]] = []
     for event in events:
+        payload = event.get("payload") or event
+        event_id = _calendar_event_identifier(event)
         trigger = _as_trigger_from_event(event, contains_trigger=contains_trigger)
         if trigger is None:
-            payload = event.get("payload") or event
-            event_id = _calendar_event_identifier(event)
             log_step(
                 "calendar",
                 "event_discarded",
@@ -163,6 +163,16 @@ def gather_calendar_triggers(
             if event_id:
                 log_event({"event_id": event_id, "status": statuses.NOT_RELEVANT})
             continue
+        log_step(
+            "calendar",
+            "trigger_detected",
+            {
+                "event": {
+                    "id": event_id,
+                    "summary": payload.get("summary", ""),
+                }
+            },
+        )
         triggers.append(trigger)
     return triggers
 

--- a/tests/unit/test_calendar_triggers.py
+++ b/tests/unit/test_calendar_triggers.py
@@ -32,6 +32,11 @@ def test_gather_calendar_triggers_accepts_payload_id():
     assert triggers[0]["payload"]["summary"] == "besuchsvorbereitung"
     assert not any(step[1] == "event_discarded" for step in logged_steps)
     assert not any(event.get("status") == "no_calendar_events" for event in logged_events)
+    trigger_steps = [step for step in logged_steps if step[1] == "trigger_detected"]
+    assert len(trigger_steps) == 1
+    assert trigger_steps[0][0] == "calendar"
+    assert trigger_steps[0][2]["event"]["id"] == "abc"
+    assert trigger_steps[0][2]["event"]["summary"] == "besuchsvorbereitung"
 
 
 def test_normalized_event_keeps_recipient():


### PR DESCRIPTION
## Summary
- log a `trigger_detected` step for calendar events that produce triggers, including the event identifier and summary
- extend the calendar trigger unit test to ensure the logging hook records the trigger detection

## Testing
- pytest tests/unit/test_calendar_triggers.py

------
https://chatgpt.com/codex/tasks/task_e_68cc5410ae10832bb11b5c9fb1e3a36a