### PR TITLE
Improve field extraction and reminder handling

### DIFF
--- a/core/run_loop.py
+++ b/core/run_loop.py
@@ -239,11 +239,24 @@ def notify_reminders(
         for trigger in triggers:
             payload = trigger.get("payload", {})
             event_id = payload.get("event_id")
-            
-            # Only process triggers that need reminders
-            if event_id and not payload.get("company_name") and not payload.get("domain"):
+            if not event_id:
+                continue
+
+            missing: List[str] = []
+            if not payload.get("company_name"):
+                missing.append("company_name")
+            if not payload.get("domain"):
+                missing.append("domain")
+
+            if missing:
+                existing_missing = trigger.get("missing")
+                if isinstance(existing_missing, list) and existing_missing:
+                    combined = list(dict.fromkeys(existing_missing + missing))
+                    trigger["missing"] = combined
+                else:
+                    trigger["missing"] = missing
                 reminder_triggers.append(trigger)
-        
+
         if reminder_triggers:
             reminder_service.check_and_notify(reminder_triggers)
     except Exception:

--- a/tests/unit/test_field_completion_agent.py
+++ b/tests/unit/test_field_completion_agent.py
@@ -1,0 +1,38 @@
+from agents import field_completion_agent
+
+
+def _make_trigger(payload):
+    return {"payload": payload, "source": "calendar"}
+
+
+def test_field_completion_extracts_from_labeled_description():
+    description = (
+        "Agenda for kickoff meeting\n"
+        "Company Name: Beispiel GmbH\n"
+        "Website: HTTPS://Example.COM/path"
+    )
+    trigger = _make_trigger({"description": description})
+
+    result = field_completion_agent.run(trigger)
+
+    assert result["company_name"] == "Beispiel GmbH"
+    assert result["domain"] == "example.com"
+
+
+def test_field_completion_uses_extended_properties():
+    trigger = _make_trigger(
+        {
+            "summary": "Strategy workshop",
+            "extendedProperties": {
+                "private": {
+                    "company_label": "Future Mobility AG",
+                    "company_domain": "Future-Mobility.io",
+                }
+            },
+        }
+    )
+
+    result = field_completion_agent.run(trigger)
+
+    assert result["company_name"] == "Future Mobility AG"
+    assert result["domain"] == "future-mobility.io"

--- a/tests/unit/test_run_loop_notify_reminders.py
+++ b/tests/unit/test_run_loop_notify_reminders.py
@@ -1,0 +1,32 @@
+from core import run_loop
+
+
+class DummyReminder:
+    def __init__(self):
+        self.triggers = []
+
+    def check_and_notify(self, triggers):
+        self.triggers.extend(triggers)
+
+
+def test_notify_reminders_handles_partial_missing():
+    reminder = DummyReminder()
+    trigger = {
+        "payload": {"event_id": "e1", "company_name": "ACME"},
+    }
+
+    run_loop.notify_reminders([trigger], reminder_service=reminder)
+
+    assert reminder.triggers
+    assert reminder.triggers[0]["missing"] == ["domain"]
+
+
+def test_notify_reminders_skips_complete_triggers():
+    reminder = DummyReminder()
+    trigger = {
+        "payload": {"event_id": "e2", "company_name": "ACME", "domain": "acme.com"},
+    }
+
+    run_loop.notify_reminders([trigger], reminder_service=reminder)
+
+    assert reminder.triggers == []


### PR DESCRIPTION
## Summary
- enhance the regex field completion agent to understand labelled company data, skip noisy values, and traverse extended payload properties when building its search text
- tighten company-name validation and whitespace normalisation to avoid false positives while still capturing realistic business names
- update reminder notification logic to trigger whenever either the company name or domain is missing and merge previously computed missing fields
- add targeted tests covering complex field extraction cases and the reminder notification flow

## Testing
- pytest tests/unit/test_field_completion_agent.py tests/unit/test_run_loop_notify_reminders.py

------
https://chatgpt.com/codex/tasks/task_e_68cd4cde5de4832b87cb57a9a793027e