### PR TITLE
Ensure reminder scheduler uses aware datetimes

### DIFF
--- a/agents/reminder_service.py
+++ b/agents/reminder_service.py
@@ -162,8 +162,8 @@ class ReminderScheduler:
         """Run the scheduler loop indefinitely."""
         while True:
             now = self._now()
-            reminder_at = datetime.combine(now.date(), dtime(hour=10, minute=0))
-            escalation_at = datetime.combine(now.date(), dtime(hour=15, minute=0))
+            reminder_at = now.replace(hour=10, minute=0, second=0, microsecond=0)
+            escalation_at = now.replace(hour=15, minute=0, second=0, microsecond=0)
 
             if now < reminder_at:
                 next_run = reminder_at

--- a/tests/unit/test_reminder_scheduler.py
+++ b/tests/unit/test_reminder_scheduler.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import sys
-from datetime import datetime, time as dtime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -118,9 +118,9 @@ def test_scheduler_run_flow(monkeypatch):
     scheduler = ReminderScheduler()
 
     times = [
-        datetime(2023, 1, 1, 9, 0),
-        datetime(2023, 1, 1, 10, 0),
-        datetime(2023, 1, 1, 15, 0),
+        datetime(2023, 1, 1, 9, 0, tzinfo=timezone.utc),
+        datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+        datetime(2023, 1, 1, 15, 0, tzinfo=timezone.utc),
     ]
 
     def fake_now():


### PR DESCRIPTION
## Summary
- update the reminder scheduler to build reminder and escalation times from the current aware timestamp
- adjust the scheduler unit test to use timezone-aware datetimes so the aware path is exercised

## Testing
- pytest tests/unit/test_reminder_scheduler.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ce7e69d370832b8c1d9e05cecdf96f