### PR TITLE
Ensure timezone-aware logging and async event handling

### DIFF
--- a/a2a_logging/notifications.py
+++ b/a2a_logging/notifications.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import json
 
@@ -24,7 +24,7 @@ def log_email(
     timestamp: Optional[str] = None,
 ) -> None:
     """Log an e-mail notification event."""
-    ts = timestamp or datetime.utcnow().isoformat()
+    ts = timestamp or datetime.now(timezone.utc).isoformat()
     payload = {
         "timestamp": ts,
         "sender": sender,

--- a/agents/reminder_service.py
+++ b/agents/reminder_service.py
@@ -41,7 +41,10 @@ def log_event(record: dict) -> None:
     payload = {
         "event_id": record.get("event_id"),
         "status": record.get("status"),
-        "timestamp": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
         "severity": record.get("severity", "info"),
         "workflow_id": wf_id,
         "details": {},

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,9 @@
+# Latest Changes
+
+## 2025-09-20
+- Replaced deprecated `datetime.utcnow()` usages across calendar integrations, reminder logging, and notification logging with
+  timezone-aware `datetime.now(timezone.utc)` to eliminate warnings and ensure consistent timestamps.
+- Updated the event bus to execute coroutine subscribers by scheduling them on the active loop (or running them synchronously
+  when no loop is available), maintaining full audit logging for async execution paths.
+- Converted the autonomous workflow smoke test to use assertions instead of returning values, removing pytest warnings while
+  preserving diagnostic output.

--- a/test_autonomous_workflow.py
+++ b/test_autonomous_workflow.py
@@ -22,6 +22,7 @@ def test_autonomous_workflow():
     for agent in agents:
         capabilities = [cap.value for cap in agent.metadata.capabilities]
         print(f"   - {agent.metadata.name}: {capabilities}")
+    assert agents, "No agents are registered with the orchestrator"
     
     # Test manual trigger
     print("\n🚀 Testing manual trigger...")
@@ -31,19 +32,21 @@ def test_autonomous_workflow():
         "creator": "test@example.com",
         "summary": "Meeting with Test GmbH for research"
     })
-    
+
     print(f"✅ Workflow triggered with correlation ID: {correlation_id}")
-    
+    assert correlation_id, "Manual trigger did not return a correlation ID"
+
     # Check workflow status
     status = autonomous_orchestrator.get_workflow_status(correlation_id)
     print(f"✅ Workflow status: {status}")
-    
+    assert status is not None, "Workflow status lookup returned None"
+
     # Check event history
     events = autonomous_orchestrator.event_bus.get_events(correlation_id)
     print(f"✅ {len(events)} events in history")
-    
+    assert events, "No events were recorded for the workflow"
+
     print("\n🎉 Autonomous workflow test completed!")
-    return True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` usages with timezone-aware timestamps across calendar integration, reminder logging, and notification logging
- teach the event bus to execute coroutine subscribers via `asyncio.create_task` (or run them synchronously when no loop is active) while logging scheduling activity
- convert the autonomous workflow smoke test to use assertions and document the changes in `summary.md`

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce77eb96d0832b9b759ff2f33f0c63