### PR TITLE
Fix autonomous workflow trigger handling and email fallbacks

### DIFF
--- a/agents/autonomous_email_agent.py
+++ b/agents/autonomous_email_agent.py
@@ -33,22 +33,74 @@ class AutonomousEmailAgent(BaseAgent):
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:
         """Process email request."""
-        email_type = event.payload.get("type")
-        payload = event.payload.get("payload", {})
-        
+        data = event.payload or {}
+        email_type = data.get("type")
+        payload = data.get("payload", {})
+        metadata = data.get("metadata") or {}
+
         if email_type == "missing_fields":
-            return await self._handle_missing_fields_email(payload, event.payload.get("missing", []))
+            return await self._handle_missing_fields_email(payload, data.get("missing", []), metadata)
         elif email_type == "report":
-            return await self._handle_report_email(payload, event.payload.get("attachments", []))
-        
+            return await self._handle_report_email(payload, data.get("attachments", []), metadata)
+
         return {}
-    
-    async def _handle_missing_fields_email(self, payload: Dict[str, Any], missing: list) -> Dict[str, Any]:
+
+    def _resolve_email(self, candidate: Any) -> Optional[str]:
+        if isinstance(candidate, str):
+            candidate = candidate.strip()
+            return candidate or None
+        if isinstance(candidate, dict):
+            for key in ("email", "address", "value"):
+                value = candidate.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return None
+
+    def _find_creator_email(
+        self, payload: Dict[str, Any], metadata: Dict[str, Any]
+    ) -> Optional[str]:
+        candidates = [
+            payload.get("creatorEmail"),
+            payload.get("creator_email"),
+            payload.get("creator"),
+            metadata.get("creator"),
+            payload.get("organizerEmail"),
+            payload.get("organizer_email"),
+            payload.get("organizer"),
+            metadata.get("recipient"),
+        ]
+        for candidate in candidates:
+            email = self._resolve_email(candidate)
+            if email:
+                return email
+        return None
+
+    def _find_report_recipient(
+        self, payload: Dict[str, Any], metadata: Dict[str, Any]
+    ) -> Optional[str]:
+        candidates = [
+            payload.get("recipient"),
+            metadata.get("recipient"),
+            payload.get("creator"),
+            payload.get("creatorEmail"),
+            metadata.get("creator"),
+            payload.get("organizerEmail"),
+            payload.get("organizer"),
+        ]
+        for candidate in candidates:
+            email = self._resolve_email(candidate)
+            if email:
+                return email
+        return None
+
+    async def _handle_missing_fields_email(
+        self, payload: Dict[str, Any], missing: list, metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Send missing fields request email."""
-        creator_email = payload.get("creator") or payload.get("creatorEmail")
+        creator_email = self._find_creator_email(payload, metadata)
         if not creator_email:
             return {"error": "No creator email found"}
-        
+
         try:
             email_sender.send_email(
                 to=creator_email,
@@ -60,12 +112,14 @@ class AutonomousEmailAgent(BaseAgent):
         except Exception as e:
             return {"error": str(e)}
     
-    async def _handle_report_email(self, payload: Dict[str, Any], attachments: list) -> Dict[str, Any]:
+    async def _handle_report_email(
+        self, payload: Dict[str, Any], attachments: list, metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Send report email."""
-        recipient = payload.get("creator") or payload.get("recipient")
+        recipient = self._find_report_recipient(payload, metadata)
         if not recipient:
             return {"error": "No recipient found"}
-        
+
         try:
             email_sender.send_email(
                 to=recipient,

--- a/agents/autonomous_field_completion_agent.py
+++ b/agents/autonomous_field_completion_agent.py
@@ -47,12 +47,28 @@ class AutonomousFieldCompletionAgent(BaseAgent):
     def process_event_sync(self, event: Event) -> Optional[Dict[str, Any]]:
         """Process field completion request synchronously."""
         # Convert event to trigger format expected by existing agent
+        payload = event.payload or {}
+        if isinstance(payload, dict) and isinstance(payload.get("payload"), dict):
+            trigger_payload = payload["payload"]
+            source = payload.get("source", "calendar")
+            trigger_creator = payload.get("creator")
+            trigger_recipient = payload.get("recipient")
+        else:
+            trigger_payload = payload if isinstance(payload, dict) else {}
+            source = payload.get("source", "calendar") if isinstance(payload, dict) else "calendar"
+            trigger_creator = payload.get("creator") if isinstance(payload, dict) else None
+            trigger_recipient = payload.get("recipient") if isinstance(payload, dict) else None
+
         trigger = {
-            "payload": event.payload,
-            "source": "calendar"
+            "payload": trigger_payload,
+            "source": source,
         }
-        
+        if trigger_creator is not None:
+            trigger["creator"] = trigger_creator
+        if trigger_recipient is not None:
+            trigger["recipient"] = trigger_recipient
+
         # Run existing field completion logic
         result = field_completion_run(trigger)
-        
+
         return result if result else {}

--- a/agents/autonomous_research_agent.py
+++ b/agents/autonomous_research_agent.py
@@ -33,12 +33,25 @@ class AutonomousInternalSearchAgent(BaseAgent):
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:
         """Process research request."""
+        payload = event.payload or {}
+        if isinstance(payload, dict) and isinstance(payload.get("payload"), dict):
+            trigger_payload = payload["payload"]
+            source = payload.get("source", "calendar")
+            creator = payload.get("creator")
+            recipient = payload.get("recipient")
+        else:
+            trigger_payload = payload if isinstance(payload, dict) else {}
+            source = payload.get("source", "calendar") if isinstance(payload, dict) else "calendar"
+            creator = payload.get("creator") if isinstance(payload, dict) else None
+            recipient = payload.get("recipient") if isinstance(payload, dict) else None
+
         trigger = {
-            "payload": event.payload,
-            "source": "calendar",
-            "creator": event.payload.get("creator")
+            "payload": trigger_payload,
+            "source": source,
+            "creator": creator,
+            "recipient": recipient,
         }
-        
+
         result = agent_internal_search.run(trigger)
         
         # Skip if missing fields
@@ -72,11 +85,24 @@ class AutonomousExternalSearchAgent(BaseAgent):
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:
         """Process external research request."""
+        payload = event.payload or {}
+        if isinstance(payload, dict) and isinstance(payload.get("payload"), dict):
+            trigger_payload = payload["payload"]
+            source = payload.get("source", "calendar")
+            creator = payload.get("creator")
+            recipient = payload.get("recipient")
+        else:
+            trigger_payload = payload if isinstance(payload, dict) else {}
+            source = payload.get("source", "calendar") if isinstance(payload, dict) else "calendar"
+            creator = payload.get("creator") if isinstance(payload, dict) else None
+            recipient = payload.get("recipient") if isinstance(payload, dict) else None
+
         trigger = {
-            "payload": event.payload,
-            "source": "calendar",
-            "creator": event.payload.get("creator")
+            "payload": trigger_payload,
+            "source": source,
+            "creator": creator,
+            "recipient": recipient,
         }
-        
+
         result = agent_external_level1_company_search.run(trigger)
         return result

--- a/tests/unit/test_autonomous_agents.py
+++ b/tests/unit/test_autonomous_agents.py
@@ -1,0 +1,139 @@
+import asyncio
+from datetime import datetime, timezone
+
+from core.agent_controller import AgentRegistry, WorkflowCoordinator
+from core.event_bus import Event, EventBus, EventType
+from agents.autonomous_research_agent import AutonomousInternalSearchAgent
+from agents.autonomous_email_agent import AutonomousEmailAgent
+from agents import agent_internal_search
+from integrations import email_sender
+
+
+def test_workflow_coordinator_extracts_payload_and_metadata():
+    bus = EventBus()
+    registry = AgentRegistry()
+    coordinator = WorkflowCoordinator(registry, bus)
+
+    captured = []
+    bus.subscribe(EventType.FIELD_COMPLETION_REQUESTED, lambda event: captured.append(event))
+
+    trigger_payload = {
+        "source": "calendar",
+        "creator": "owner@example.com",
+        "recipient": "owner@example.com",
+        "payload": {
+            "event_id": "evt1",
+            "summary": "Intro call",
+        },
+    }
+
+    bus.publish(EventType.TRIGGER_RECEIVED, trigger_payload)
+
+    assert captured, "Field completion request was not published"
+    event = captured[0]
+    assert event.payload["event_id"] == "evt1"
+    assert event.payload["summary"] == "Intro call"
+    assert event.payload["creator"] == "owner@example.com"
+    state = next(iter(coordinator._active_workflows.values()))
+    assert state["metadata"]["creator"] == "owner@example.com"
+    assert state["metadata"]["recipient"] == "owner@example.com"
+
+
+def test_workflow_coordinator_missing_fields_requests_email():
+    bus = EventBus()
+    registry = AgentRegistry()
+    coordinator = WorkflowCoordinator(registry, bus)
+
+    email_events = []
+    bus.subscribe(EventType.EMAIL_REQUESTED, lambda event: email_events.append(event))
+
+    trigger_payload = {
+        "source": "calendar",
+        "creator": "owner@example.com",
+        "recipient": "owner@example.com",
+        "payload": {
+            "event_id": "evt2",
+            "summary": "Needs data",
+        },
+    }
+
+    correlation_id = bus.publish(EventType.TRIGGER_RECEIVED, trigger_payload)
+
+    fc_event = Event(
+        id="fc",
+        type=EventType.FIELD_COMPLETION_COMPLETED,
+        payload={},
+        timestamp=datetime.now(timezone.utc),
+        correlation_id=correlation_id,
+    )
+    coordinator._handle_field_completion(fc_event)
+
+    assert email_events, "Missing fields email was not requested"
+    email_event = email_events[0]
+    payload = email_event.payload
+    assert payload["missing"] == ["company_name", "domain"]
+    assert payload["payload"]["creator"] == "owner@example.com"
+    assert payload["metadata"]["creator"] == "owner@example.com"
+
+
+def test_autonomous_internal_search_agent_unwraps_payload(monkeypatch):
+    bus = EventBus()
+    agent = AutonomousInternalSearchAgent(bus)
+
+    captured = {}
+
+    def _run(trigger):
+        captured["trigger"] = trigger
+        return {"status": "ok"}
+
+    monkeypatch.setattr(agent_internal_search, "run", _run)
+
+    payload = {
+        "event_id": "evt3",
+        "company_name": "ACME",
+        "creator": "owner@example.com",
+    }
+    event = Event(
+        id="research",
+        type=EventType.RESEARCH_REQUESTED,
+        payload=payload,
+        timestamp=datetime.now(timezone.utc),
+    )
+
+    asyncio.run(agent.process_event(event))
+
+    trigger = captured["trigger"]
+    assert trigger["payload"] is payload
+    assert trigger["source"] == "calendar"
+    assert trigger["creator"] == "owner@example.com"
+
+
+def test_autonomous_email_agent_missing_fields_uses_metadata(monkeypatch):
+    bus = EventBus()
+    agent = AutonomousEmailAgent(bus)
+
+    sent = []
+
+    def _send_email(**kwargs):
+        sent.append(kwargs)
+
+    monkeypatch.setattr(email_sender, "send_email", _send_email)
+
+    payload = {"event_id": "evt4"}
+    metadata = {"creator": None, "recipient": "fallback@example.com"}
+    event = Event(
+        id="email",
+        type=EventType.EMAIL_REQUESTED,
+        payload={
+            "type": "missing_fields",
+            "payload": payload,
+            "missing": ["domain"],
+            "metadata": metadata,
+        },
+        timestamp=datetime.now(timezone.utc),
+    )
+
+    asyncio.run(agent.process_event(event))
+
+    assert sent, "Email was not sent"
+    assert sent[0]["to"] == "fallback@example.com"


### PR DESCRIPTION
## Summary
- unwrap calendar trigger payloads in the workflow coordinator and keep metadata for downstream agents
- adjust autonomous field completion, research, and email agents to use the normalized payloads and improved email fallbacks
- add unit tests covering trigger handling, research payloads, and email address resolution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce8b33c170832bad15f114a0d76b5a