### PR TITLE
Ensure autonomous workflow completes end-to-end in tests

### DIFF
--- a/agents/autonomous_email_agent.py
+++ b/agents/autonomous_email_agent.py
@@ -23,12 +23,20 @@ class AutonomousEmailAgent(BaseAgent):
     
     def _register_handlers(self) -> None:
         """Register event handlers."""
-        def sync_handler(event):
+        def sync_handler(event: Event) -> None:
             import asyncio
+            import threading
+
             try:
-                asyncio.create_task(self.handle_event(event))
-            except Exception:
+                asyncio.get_running_loop()
+            except RuntimeError:
                 asyncio.run(self.handle_event(event))
+            else:
+                thread = threading.Thread(
+                    target=lambda: asyncio.run(self.handle_event(event))
+                )
+                thread.start()
+                thread.join()
         self.event_bus.subscribe(EventType.EMAIL_REQUESTED, sync_handler)
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:

--- a/agents/autonomous_field_completion_agent.py
+++ b/agents/autonomous_field_completion_agent.py
@@ -23,36 +23,47 @@ class AutonomousFieldCompletionAgent(BaseAgent):
     
     def _register_handlers(self) -> None:
         """Register event handlers."""
-        # Use sync wrapper for event handling
-        def sync_handler(event):
+
+        def sync_handler(event: Event) -> None:
+            """Execute the async handler in synchronous contexts."""
+            import asyncio
+            import threading
+
             try:
-                # Run synchronously - no async needed for field completion
-                result = self.process_event_sync(event)
-                if result:
-                    self.event_bus.publish(
-                        EventType.FIELD_COMPLETION_COMPLETED,
-                        result,
-                        source_agent=self.metadata.name
-                    )
-            except Exception as e:
-                from core.utils import log_step
-                log_step("field_completion_agent", "sync_handler_error", {"error": str(e)}, severity="error")
-                
+                asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(self.handle_event(event))
+            else:
+                thread = threading.Thread(
+                    target=lambda: asyncio.run(self.handle_event(event))
+                )
+                thread.start()
+                thread.join()
+
         self.event_bus.subscribe(EventType.FIELD_COMPLETION_REQUESTED, sync_handler)
-    
+
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:
         """Process field completion request."""
-        return self.process_event_sync(event)
-    
-    def process_event_sync(self, event: Event) -> Optional[Dict[str, Any]]:
+        return self._process_event_sync(event)
+
+    def _process_event_sync(self, event: Event) -> Optional[Dict[str, Any]]:
         """Process field completion request synchronously."""
         # Convert event to trigger format expected by existing agent
         trigger = {
             "payload": event.payload,
             "source": "calendar"
         }
-        
+
         # Run existing field completion logic
-        result = field_completion_run(trigger)
-        
-        return result if result else {}
+        result = field_completion_run(trigger) or {}
+
+        payload = event.payload or {}
+        nested_payload = payload.get("payload") if isinstance(payload.get("payload"), dict) else {}
+
+        for key in ("company_name", "domain", "industry_group", "industry", "creator"):
+            if key not in result and key in payload:
+                result[key] = payload[key]
+            elif key not in result and key in nested_payload:
+                result[key] = nested_payload[key]
+
+        return result

--- a/agents/autonomous_report_agent.py
+++ b/agents/autonomous_report_agent.py
@@ -25,12 +25,20 @@ class AutonomousReportAgent(BaseAgent):
     
     def _register_handlers(self) -> None:
         """Register event handlers."""
-        def sync_handler(event):
+        def sync_handler(event: Event) -> None:
             import asyncio
+            import threading
+
             try:
-                asyncio.create_task(self.handle_event(event))
-            except Exception:
+                asyncio.get_running_loop()
+            except RuntimeError:
                 asyncio.run(self.handle_event(event))
+            else:
+                thread = threading.Thread(
+                    target=lambda: asyncio.run(self.handle_event(event))
+                )
+                thread.start()
+                thread.join()
         self.event_bus.subscribe(EventType.REPORT_REQUESTED, sync_handler)
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:

--- a/agents/autonomous_research_agent.py
+++ b/agents/autonomous_research_agent.py
@@ -23,12 +23,20 @@ class AutonomousInternalSearchAgent(BaseAgent):
     
     def _register_handlers(self) -> None:
         """Register event handlers."""
-        def sync_handler(event):
+        def sync_handler(event: Event) -> None:
             import asyncio
+            import threading
+
             try:
-                asyncio.create_task(self.handle_event(event))
-            except Exception:
+                asyncio.get_running_loop()
+            except RuntimeError:
                 asyncio.run(self.handle_event(event))
+            else:
+                thread = threading.Thread(
+                    target=lambda: asyncio.run(self.handle_event(event))
+                )
+                thread.start()
+                thread.join()
         self.event_bus.subscribe(EventType.RESEARCH_REQUESTED, sync_handler)
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:
@@ -36,7 +44,8 @@ class AutonomousInternalSearchAgent(BaseAgent):
         trigger = {
             "payload": event.payload,
             "source": "calendar",
-            "creator": event.payload.get("creator")
+            "creator": event.payload.get("creator"),
+            "recipient": event.payload.get("recipient"),
         }
         
         result = agent_internal_search.run(trigger)
@@ -62,12 +71,20 @@ class AutonomousExternalSearchAgent(BaseAgent):
     
     def _register_handlers(self) -> None:
         """Register event handlers."""
-        def sync_handler(event):
+        def sync_handler(event: Event) -> None:
             import asyncio
+            import threading
+
             try:
-                asyncio.create_task(self.handle_event(event))
-            except Exception:
+                asyncio.get_running_loop()
+            except RuntimeError:
                 asyncio.run(self.handle_event(event))
+            else:
+                thread = threading.Thread(
+                    target=lambda: asyncio.run(self.handle_event(event))
+                )
+                thread.start()
+                thread.join()
         self.event_bus.subscribe(EventType.RESEARCH_REQUESTED, sync_handler)
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:
@@ -75,7 +92,8 @@ class AutonomousExternalSearchAgent(BaseAgent):
         trigger = {
             "payload": event.payload,
             "source": "calendar",
-            "creator": event.payload.get("creator")
+            "creator": event.payload.get("creator"),
+            "recipient": event.payload.get("recipient"),
         }
         
         result = agent_external_level1_company_search.run(trigger)

--- a/core/agent_controller.py
+++ b/core/agent_controller.py
@@ -74,8 +74,8 @@ class BaseAgent(ABC):
             })
             
             result = await self.process_event(event)
-            
-            if result:
+
+            if result is not None:
                 # Publish completion event
                 completion_type = self._get_completion_event_type(event.type)
                 if completion_type:

--- a/core/autonomous_orchestrator.py
+++ b/core/autonomous_orchestrator.py
@@ -116,7 +116,11 @@ class AutonomousOrchestrator:
         
         # Determine current status from events
         latest_event = events[-1]
-        
+        for event in reversed(events):
+            if event.type in (EventType.WORKFLOW_COMPLETED, EventType.WORKFLOW_FAILED):
+                latest_event = event
+                break
+
         status_map = {
             EventType.TRIGGER_RECEIVED: "triggered",
             EventType.FIELD_COMPLETION_COMPLETED: "field_completion_done",

--- a/test_full_workflow.py
+++ b/test_full_workflow.py
@@ -1,24 +1,32 @@
 #!/usr/bin/env python3
-"""Full end-to-end workflow test."""
+"""Full end-to-end workflow test matching the workflow schema."""
 
-import asyncio
+from __future__ import annotations
+
+import os
 import sys
 import time
 from pathlib import Path
 
+# Ensure deterministic test configuration
+os.environ.setdefault("LIVE_MODE", "0")
+
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent))
 
+import pytest
+
+from config.settings import SETTINGS
 from core.autonomous_orchestrator import autonomous_orchestrator
-from core.utils import log_step
+from core.event_bus import EventType
+
+# Reflect the test configuration in the settings singleton
+SETTINGS.live_mode = 0
 
 
-async def test_full_workflow():
-    """Test complete autonomous workflow."""
-    
-    print("🚀 Starting full A2A workflow test...")
-    
-    # Mock trigger data with complete information
+def test_full_workflow() -> None:
+    """Execute the autonomous workflow and assert the expected artefacts."""
+
     trigger_data = {
         "source": "calendar",
         "creator": "test@example.com",
@@ -31,47 +39,57 @@ async def test_full_workflow():
             "domain": "techcorp.com",
             "creator": "test@example.com",
             "industry_group": "Technology",
-            "industry": "Software Development"
-        }
+            "industry": "Software Development",
+        },
     }
-    
+
+    correlation_id = autonomous_orchestrator.process_manual_trigger(trigger_data)
+
+    deadline = time.time() + 20
+    events = []
+    while time.time() < deadline:
+        events = autonomous_orchestrator.event_bus.get_events(correlation_id)
+        if any(event.type == EventType.WORKFLOW_COMPLETED for event in events):
+            break
+        time.sleep(0.2)
+    else:
+        pytest.fail("Workflow did not reach completion event")
+
+    status = autonomous_orchestrator.get_workflow_status(correlation_id)
+    assert status.get("status") == "completed", f"Unexpected workflow status: {status}"
+
+    event_types = {event.type for event in events}
+
+    for expected_type in (
+        EventType.FIELD_COMPLETION_REQUESTED,
+        EventType.FIELD_COMPLETION_COMPLETED,
+        EventType.RESEARCH_REQUESTED,
+        EventType.RESEARCH_COMPLETED,
+        EventType.CONSOLIDATION_REQUESTED,
+        EventType.CONSOLIDATION_COMPLETED,
+        EventType.REPORT_REQUESTED,
+        EventType.REPORT_COMPLETED,
+        EventType.WORKFLOW_COMPLETED,
+    ):
+        assert expected_type in event_types, f"Missing workflow step: {expected_type.value}"
+
+    pdf_files = sorted(SETTINGS.exports_dir.glob("*.pdf"))
+    csv_files = sorted(SETTINGS.exports_dir.glob("*.csv"))
+
+    assert pdf_files, "Expected a PDF dossier to be generated"
+    assert csv_files, "Expected a CSV dossier to be generated"
+
+    latest_pdf = pdf_files[-1]
+    latest_csv = csv_files[-1]
+
+    assert latest_pdf.stat().st_size > 0, "Generated PDF is empty"
+    assert latest_csv.stat().st_size > 0, "Generated CSV is empty"
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    success = True
     try:
-        # Process trigger
-        correlation_id = autonomous_orchestrator.process_manual_trigger(trigger_data)
-        print(f"✓ Trigger processed with correlation ID: {correlation_id}")
-        
-        # Wait for processing
-        print("⏳ Waiting for workflow processing...")
-        await asyncio.sleep(3)
-        
-        # Check final status
-        status = autonomous_orchestrator.get_workflow_status(correlation_id)
-        print(f"✓ Final workflow status: {status}")
-        
-        # Check if outputs were generated
-        from config.settings import SETTINGS
-        
-        pdf_files = list(SETTINGS.exports_dir.glob("*.pdf"))
-        csv_files = list(SETTINGS.exports_dir.glob("*.csv"))
-        
-        print(f"✓ Generated files:")
-        print(f"  - PDF files: {len(pdf_files)}")
-        print(f"  - CSV files: {len(csv_files)}")
-        
-        if pdf_files:
-            print(f"  - Latest PDF: {pdf_files[-1]}")
-        if csv_files:
-            print(f"  - Latest CSV: {csv_files[-1]}")
-        
-        print("🎉 Full workflow test completed successfully!")
-        return True
-        
-    except Exception as e:
-        log_step("test", "full_workflow_error", {"error": str(e)}, severity="critical")
-        print(f"❌ Full workflow test failed: {e}")
-        return False
-
-
-if __name__ == "__main__":
-    success = asyncio.run(test_full_workflow())
+        test_full_workflow()
+    except AssertionError:
+        success = False
     sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- run autonomous agent handlers synchronously using dedicated threads so events propagate with correlation IDs
- normalise field completion payloads for downstream agents and prefer terminal workflow events when reporting status
- rewrite the full workflow test to operate offline and assert the presence of every workflow stage and generated exports

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68ceb18eb474832b94a401c4828939d9