### PR TITLE
Align missing info email subject with workflow

### DIFF
--- a/integrations/email_client.py
+++ b/integrations/email_client.py
@@ -47,7 +47,12 @@ def send_email(
         },
     )
 
-    subject = "Missing information for research"
+    subject_base = "Missing Information Required - A2A Research"
+    subject = (
+        f"{subject_base} (Task: {task_id})"
+        if task_id is not None
+        else subject_base
+    )
     # Friendlier copy with bullets when available
     if has_fields:
         bullets = "\n".join(f"- {f}" for f in fields_list)

--- a/tests/integration/test_workflow_end_to_end.py
+++ b/tests/integration/test_workflow_end_to_end.py
@@ -115,7 +115,7 @@ def test_ai_failure_triggers_email(monkeypatch):
     assert f'"status": "{statuses.PENDING}"' in logs
     assert len(send_calls) == 1  # Only reminder email, no report email without company data
     subjects = {c["subject"] for c in send_calls}
-    assert "Missing information for research" in subjects
+    assert "Missing Information Required - A2A Research (Task: e3)" in subjects
     # No report email should be sent when company data is missing
     assert "Your A2A research report" not in subjects
 


### PR DESCRIPTION
## Summary
- update the missing information reminder email subject to match the workflow format when a task id is available
- adjust the integration test to assert on the updated subject line

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cf01cf34a8832b8a0c8b1be83693fe