### PR TITLE
Fix missing info email subject regression

### DIFF
--- a/integrations/email_client.py
+++ b/integrations/email_client.py
@@ -29,6 +29,7 @@ def send_email(
     missing_fields: Iterable[str],
     *,
     task_id: Optional[str] = None,
+    event_id: Optional[str] = None,
 ) -> None:
     """Send a notification e-mail about missing fields (friendly, deterministic)."""
     _mail_from()
@@ -44,6 +45,8 @@ def send_email(
             "recipient": employee_email,
             "missing_fields": fields_list,
             "has_fields": has_fields,
+            "task_id": task_id,
+            "event_id": event_id,
         },
     )
 
@@ -69,5 +72,7 @@ def send_email(
     kwargs = {}
     if task_id is not None:
         kwargs["task_id"] = task_id
+    if event_id is not None:
+        kwargs["event_id"] = event_id
 
     email_sender.send_email(to=employee_email, subject=subject, body=body, **kwargs)


### PR DESCRIPTION
## Summary
- delegate missing information notifications to the shared email client inside the workflow run loop and fall back to the raw sender when MAIL_FROM is unavailable
- include task and event identifiers in the email client logging and forwarding metadata so downstream code receives the same context

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cf0a498184832b9ff71a2d283832d2