### PR TITLE
Align fallback missing-info email subject

### DIFF
--- a/core/run_loop.py
+++ b/core/run_loop.py
@@ -184,7 +184,12 @@ def run_researchers(
                                 cleaned = sorted(
                                     {f.strip() for f in missing if f and isinstance(f, str)}
                                 )
-                                subject = "Missing information for research"
+                                subject_base = "Missing Information Required - A2A Research"
+                                subject = (
+                                    f"{subject_base} (Task: {task_id})"
+                                    if task_id is not None
+                                    else subject_base
+                                )
                                 if cleaned:
                                     bullets = "\n".join(f"- {f}" for f in cleaned)
                                     body = (


### PR DESCRIPTION
## Summary
- ensure the fallback email sender mirrors the primary subject format
- include the task identifier in the human-in-the-loop reminder subject when available

## Testing
- python -m pytest tests/integration/test_workflow_end_to_end.py -k ai_failure -q

------
https://chatgpt.com/codex/tasks/task_e_68cf0f57e030832ba53e1010100c4cbb