### PR TITLE
refactor: replace placeholder email defaults

### DIFF
--- a/agents/autonomous_email_agent.py
+++ b/agents/autonomous_email_agent.py
@@ -58,10 +58,11 @@ class AutonomousEmailAgent(BaseAgent):
         original_payload = payload.get("payload", {})
         
         # Get recipient from original payload
+        fallback_recipient = "support@a2a-research.com"
         recipient = (
             original_payload.get("creator") or
             original_payload.get("recipient") or
-            "unknown@example.com"
+            fallback_recipient
         )
         
         # Extract context information
@@ -99,10 +100,12 @@ A2A Research Team"""
             from core.utils import log_step
             log_step("email_agent", "send_error", {"error": str(e)}, severity="error")
             return {"status": "failed", "error": str(e)}
+
     
     async def _handle_report_email(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Handle report delivery email."""
-        recipient = payload.get("recipient", "unknown@example.com")
+        fallback_recipient = "support@a2a-research.com"
+        recipient = payload.get("recipient", fallback_recipient)
         pdf_path = payload.get("pdf_path")
         
         subject = "A2A Research Report Ready"


### PR DESCRIPTION
## Summary
- replace placeholder fallback email addresses with the A2A support mailbox in the autonomous email agent
- ensure both missing field and report notifications rely on the same branded fallback address

## Testing
- python ops/no_demo_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2693b0e4832b890501f7fc33f2ad