### PR TITLE
Fix payload normalization in autonomous calendar workflow

### DIFF
--- a/agents/autonomous_research_agent.py
+++ b/agents/autonomous_research_agent.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 from core.agent_controller import BaseAgent, AgentMetadata, AgentCapability
 from core.event_bus import EventBus, Event, EventType
 from agents import agent_internal_search, agent_external_level1_company_search
+from agents.autonomous_utils import ensure_trigger_structure
 
 
 class AutonomousInternalSearchAgent(BaseAgent):
@@ -35,13 +36,12 @@ class AutonomousInternalSearchAgent(BaseAgent):
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:
         """Process research request."""
-        trigger = {
-            "payload": event.payload,
-            "source": "calendar",
-            "creator": event.payload.get("creator"),
-            "recipient": event.payload.get("recipient"),
-        }
-        
+        trigger = ensure_trigger_structure(event.payload)
+        trigger.setdefault("source", "calendar")
+        if isinstance(event.payload, dict):
+            trigger.setdefault("creator", event.payload.get("creator"))
+            trigger.setdefault("recipient", event.payload.get("recipient"))
+
         result = agent_internal_search.run(trigger)
         
         # Skip if missing fields
@@ -77,12 +77,11 @@ class AutonomousExternalSearchAgent(BaseAgent):
     
     async def process_event(self, event: Event) -> Optional[Dict[str, Any]]:
         """Process external research request."""
-        trigger = {
-            "payload": event.payload,
-            "source": "calendar",
-            "creator": event.payload.get("creator"),
-            "recipient": event.payload.get("recipient"),
-        }
-        
+        trigger = ensure_trigger_structure(event.payload)
+        trigger.setdefault("source", "calendar")
+        if isinstance(event.payload, dict):
+            trigger.setdefault("creator", event.payload.get("creator"))
+            trigger.setdefault("recipient", event.payload.get("recipient"))
+
         result = agent_external_level1_company_search.run(trigger)
         return result

--- a/agents/autonomous_utils.py
+++ b/agents/autonomous_utils.py
@@ -1,0 +1,56 @@
+"""Utility helpers for autonomous agents."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+_METADATA_KEYS = {
+    "source",
+    "workflow_id",
+    "trigger_id",
+    "correlation_id",
+}
+
+
+def ensure_trigger_structure(event_payload: Dict[str, Any] | None) -> Dict[str, Any]:
+    """Return a trigger dict with a single level of payload nesting.
+
+    Legacy agents expect triggers with top-level metadata (source, creator,
+    recipient, etc.) and the normalized event stored under the ``payload`` key.
+    When autonomous events already follow that schema we simply clone the
+    structure.  If they are passed a raw normalized event (without the wrapper),
+    we wrap it once while keeping any metadata fields that may have been
+    provided alongside it.
+    """
+    if not isinstance(event_payload, dict):
+        return {"payload": {}}
+
+    nested_payload = event_payload.get("payload")
+    if isinstance(nested_payload, dict):
+        if isinstance(nested_payload.get("payload"), dict):
+            normalized = ensure_trigger_structure(nested_payload)
+            trigger = {k: v for k, v in normalized.items() if k != "payload"}
+            trigger["payload"] = normalized["payload"]
+            return trigger
+
+        trigger = {k: v for k, v in event_payload.items() if k != "payload"}
+        trigger["payload"] = dict(nested_payload)
+        return trigger
+
+    normalized_payload = dict(event_payload)
+    trigger: Dict[str, Any] = {"payload": normalized_payload}
+
+    for key in _METADATA_KEYS:
+        if key in event_payload:
+            trigger[key] = event_payload[key]
+            # Avoid duplicating metadata inside the nested payload copy
+            normalized_payload.pop(key, None)
+
+    for key in ("creator", "recipient", "creator_name", "recipient_name"):
+        if key in event_payload:
+            value = event_payload[key]
+            trigger[key] = value
+            if not isinstance(value, dict):
+                normalized_payload.pop(key, None)
+
+    return trigger

--- a/tests/unit/test_autonomous_utils.py
+++ b/tests/unit/test_autonomous_utils.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from agents.autonomous_utils import ensure_trigger_structure
+
+
+def test_ensure_trigger_structure_preserves_canonical_payload() -> None:
+    event_payload = {
+        "source": "calendar",
+        "creator": "alice@example.com",
+        "recipient": "bob@example.com",
+        "payload": {"summary": "Call", "description": "Catch-up"},
+    }
+
+    trigger = ensure_trigger_structure(event_payload)
+
+    assert trigger["creator"] == "alice@example.com"
+    assert trigger["recipient"] == "bob@example.com"
+    assert trigger["payload"] == {"summary": "Call", "description": "Catch-up"}
+    assert "payload" not in trigger["payload"]
+
+
+def test_ensure_trigger_structure_flattens_double_wrapped_payload() -> None:
+    double_wrapped = {
+        "payload": {
+            "source": "calendar",
+            "creator": "alice@example.com",
+            "recipient": "bob@example.com",
+            "payload": {"summary": "Call"},
+        }
+    }
+
+    trigger = ensure_trigger_structure(double_wrapped)
+
+    assert trigger["creator"] == "alice@example.com"
+    assert trigger["recipient"] == "bob@example.com"
+    assert trigger["payload"] == {"summary": "Call"}
+
+
+def test_ensure_trigger_structure_wraps_raw_event_once() -> None:
+    raw_event = {
+        "source": "calendar",
+        "creator": "alice@example.com",
+        "summary": "Kick-off",
+    }
+
+    trigger = ensure_trigger_structure(raw_event)
+
+    assert trigger["creator"] == "alice@example.com"
+    assert trigger["payload"] == {"summary": "Kick-off"}
+    assert "source" not in trigger["payload"]


### PR DESCRIPTION
## Summary
- add a shared helper that normalizes trigger payloads for autonomous agents
- use the helper in field completion and research adapters to avoid double-wrapping calendar events
- cover the helper with unit tests to guard canonical, wrapped, and raw payload inputs

## Testing
- pytest tests/unit/test_autonomous_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2e286f8c832ba2737fb22bb74d9f