### PR TITLE
Centralize email sender configuration usage

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -84,8 +84,14 @@ class _Settings:
     test_mode: bool = field(default_factory=lambda: _bool_env("A2A_TEST_MODE", False))
     # Erzwingt HubSpot-Live-Daten (1) statt statischer Dummydaten (0)
     require_hubspot: int = field(default_factory=lambda: _int_env("REQUIRE_HUBSPOT", 0))
-    # Optional: E-Mail-Allowlist-Domain zum Schutz vor Fehlversand
-    smtp_allowlist_domain: str = field(
+    # --- SMTP / Mail ---
+    smtp_host: str = field(default_factory=lambda: os.getenv("SMTP_HOST", ""))
+    smtp_port: int = field(default_factory=lambda: int(os.getenv("SMTP_PORT", "587")))
+    smtp_user: str = field(default_factory=lambda: os.getenv("SMTP_USER", ""))
+    smtp_pass: str = field(default_factory=lambda: os.getenv("SMTP_PASS", ""))
+    smtp_secure: str = field(default_factory=lambda: os.getenv("SMTP_SECURE", "ssl"))
+    mail_from: str = field(default_factory=lambda: os.getenv("MAIL_FROM", ""))
+    allowlist_email_domain: str = field(
         default_factory=lambda: os.getenv("ALLOWLIST_EMAIL_DOMAIN", "")
     )
 
@@ -165,6 +171,12 @@ class _Settings:
         if sub_path.is_absolute():
             return sub_path
         return base / sub_path
+
+    @property
+    def smtp_allowlist_domain(self) -> str:
+        """Backward compatibility shim for deprecated attribute name."""
+
+        return self.allowlist_email_domain
 
 
 SETTINGS = _Settings()


### PR DESCRIPTION
## Summary
- update the email sender integration to source SMTP credentials and the allowlist domain from config.settings.SETTINGS while keeping environment fallbacks
- extend the settings dataclass with SMTP fields and an allowlist domain attribute, plus a compatibility shim for the legacy name

## Testing
- pytest tests/unit/test_email_allowlist.py tests/test_email_sender.py

------
https://chatgpt.com/codex/tasks/task_e_68d043b9de4c832b8b49034e1442c027