### PR TITLE
Switch ops compose to worker and api

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -25,4 +25,5 @@ RUN chown -R appuser:appuser /app
 USER appuser
 
 VOLUME ["/app/output", "/app/logs", "/app/data"]
-ENTRYPOINT ["python", "-m", "core.orchestrator"]
+# No hardcoded entrypoint; commands defined per service in docker-compose
+CMD ["python", "-m", "app.app.worker"]

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -1,14 +1,29 @@
-version: '3'
+version: '3.8'
 services:
-  app:
+  worker:
     build: .
     environment:
       - OUTPUT_DIR=/app/output
-      - TASKS_DB_URL=sqlite:///app/data/tasks.db
+      - EVENT_DB_URL=sqlite:////app/data/events.db
     env_file:
       - .env
     volumes:
       - ./output:/app/output
       - ./logs:/app/logs
       - ./data:/app/data
-    command: python -m core.orchestrator
+    command: python -m app.app.worker
+
+  api:
+    build: .
+    depends_on: [worker]
+    environment:
+      - OUTPUT_DIR=/app/output
+      - EVENT_DB_URL=sqlite:////app/data/events.db
+    env_file:
+      - .env
+    volumes:
+      - ./output:/app/output
+      - ./logs:/app/logs
+      - ./data:/app/data
+    command: uvicorn api.workflow_api:app --host 0.0.0.0 --port 8000
+    ports: ["8000:8000"]


### PR DESCRIPTION
## Summary
- update the ops Docker image to rely on service-specific commands instead of a hardcoded orchestrator entrypoint
- replace the ops docker-compose stack with worker and API services that share the events database and expose the API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d044f94bd4832b8287d4cc66af8fb8