### PR TITLE
Use app-scoped email reader

### DIFF
--- a/agents/email_listener.py
+++ b/agents/email_listener.py
@@ -25,7 +25,7 @@ import time
 import re
 
 from core import tasks as tasks_db
-from integrations import email_reader
+from app.integrations import email_reader
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -33,7 +33,7 @@ from core import statuses
 
 # Expose integrations so tests can monkeypatch them
 from integrations import email_sender as email_sender  # noqa: F401
-from integrations import email_reader as email_reader  # noqa: F401
+from app.integrations import email_reader as email_reader  # noqa: F401
 
 # Research agents
 from agents import reminder_service, email_listener, field_completion_agent, recovery_agent

--- a/integrations/email_sender.py
+++ b/integrations/email_sender.py
@@ -20,7 +20,7 @@ import re
 from config.env import ensure_mail_from
 from .mailer import send_email as _send_email  # tatsächlicher SMTP/Provider-Client
 from core.utils import log_step
-from integrations import email_reader
+from app.integrations import email_reader
 from config.settings import SETTINGS
 from app.core.policy.retry import MAX_ATTEMPTS, backoff_seconds
 


### PR DESCRIPTION
## Summary
- route legacy code paths through app.integrations.email_reader so the runtime uses the app-scoped adapter
- extend app.integrations.email_reader to update the event store when recording outbound messages while delegating legacy fetch helpers

## Testing
- pytest tests/unit/test_email_reader_processing.py tests/test_email_reference_parse.py

------
https://chatgpt.com/codex/tasks/task_e_68d062c04098832b98514e166631846b