### PR TITLE
Deprecate legacy autonomous agents for event bus guardrails

### DIFF
--- a/agents/autonomous_email_agent.py
+++ b/agents/autonomous_email_agent.py
@@ -1,8 +1,4 @@
-"""Deprecated legacy autonomous email agent module."""
-
-from __future__ import annotations
-
 raise RuntimeError(
-    "agents.autonomous_email_agent has been removed. "
-    "Use the orchestrator-managed workers in app.core instead."
+    "Deprecated: Use the event-driven worker (app/app/worker.py). "
+    "Agents must emit events; no direct exports/emails."
 )

--- a/agents/autonomous_report_agent.py
+++ b/agents/autonomous_report_agent.py
@@ -1,8 +1,4 @@
-"""Deprecated legacy autonomous report agent module."""
-
-from __future__ import annotations
-
 raise RuntimeError(
-    "agents.autonomous_report_agent has been removed. "
-    "Use the orchestrator-managed workers in app.core instead."
+    "Deprecated: Use the event-driven worker (app/app/worker.py). "
+    "Agents must emit events; no direct exports/emails."
 )

--- a/agents/autonomous_research_agent.py
+++ b/agents/autonomous_research_agent.py
@@ -1,8 +1,4 @@
-"""Deprecated legacy autonomous research agent module."""
-
-from __future__ import annotations
-
 raise RuntimeError(
-    "agents.autonomous_research_agent has been removed. "
-    "Use the orchestrator-managed workers in app.core instead."
+    "Deprecated: Use the event-driven worker (app/app/worker.py). "
+    "Agents must emit events; no direct exports/emails."
 )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_legacy_agents_deprecated.py
+++ b/tests/test_legacy_agents_deprecated.py
@@ -1,0 +1,16 @@
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "mod",
+    [
+        "agents.autonomous_report_agent",
+        "agents.autonomous_email_agent",
+        "agents.autonomous_research_agent",
+    ],
+)
+def test_deprecated(mod):
+    with pytest.raises(RuntimeError):
+        importlib.import_module(mod)


### PR DESCRIPTION
## Summary
- raise explicit RuntimeError when importing legacy autonomous agent modules to enforce event-bus usage
- add regression test ensuring legacy agent imports fail during migration

## Testing
- pytest tests/test_legacy_agents_deprecated.py

------
https://chatgpt.com/codex/tasks/task_e_68d1ca27f2e0832baa93ba8524d65023